### PR TITLE
Update cpu_power.csv

### DIFF
--- a/codecarbon/data/hardware/cpu_power.csv
+++ b/codecarbon/data/hardware/cpu_power.csv
@@ -1,4 +1,206 @@
 Name,TDP
+1075T,95
+255e,45
+3260 HE,45
+3280,65
+3320 EE,25
+3350 HE,45
+3365,65
+3380,65
+4226,95
+4228 HE,65
+4230 HE,65
+4234,95
+4238,95
+4240,95
+4256 EE,35
+425e,45
+4274 HE,65
+4276 HE,65
+4280,95
+4284,95
+4310 EE,35
+4332 HE,65
+4334,95
+4340,95
+4365,40
+4376 HE,65
+4386,95
+460,95
+555,80
+565,80
+570,80
+6132 HE,85
+6140,115
+6166 HE,85
+6176,115
+6180 SE,140
+6204,115
+620e,45
+6212,115
+6220,115
+6234,115
+6238,115
+6262 HE,85
+6272,115
+6274,115
+6276,115
+6278,115
+6282 SE,140
+6284 SE,140
+6308,115
+631,65
+6320,115
+6328,115
+6338P,99
+6344,115
+6348,115
+6366 HE,85
+6370P,99
+6376,115
+6378,115
+638,65
+6380,115
+6386 SE,140
+641,100
+6th Gen A10-8700P APU,15
+6th Gen A8-8600P APU,15
+6th Gen AMD PRO A10-8700B APU,15
+6th Gen AMD PRO A10-8750B APU,65
+6th Gen AMD PRO A10-8770 APU,65
+6th Gen AMD PRO A10-8770E APU,35
+6th Gen AMD PRO A10-8850B APU,95
+6th Gen AMD PRO A12-8800B APU,15
+6th Gen AMD PRO A12-8870 APU,65
+6th Gen AMD PRO A12-8870E APU,35
+6th Gen AMD PRO A4-8350B APU,65
+6th Gen AMD PRO A6-8500B APU,15
+6th Gen AMD PRO A6-8550B APU,65
+6th Gen AMD PRO A6-8570 APU,65
+6th Gen AMD PRO A6-8570E APU,35
+6th Gen AMD PRO A8-8600B APU,15
+6th Gen AMD PRO A8-8650B APU,65
+6th Gen FX-8800P APU,15
+740,65
+750,65
+750K,100
+760K,100
+7th Gen A10-9600P APU,15
+7th Gen A10-9630P APU,35
+7th Gen A10-9700 APU,65
+7th Gen A10-9700E APU,35
+7th Gen A12-9700P APU,15
+7th Gen A12-9730P APU,35
+7th Gen A12-9800 APU,65
+7th Gen A12-9800E APU,35
+7th Gen A4-9120 APU,15
+7th Gen A4-9120C APU,6
+7th Gen A4-9125 APU,15
+7th Gen A6-9210 APU,15
+7th Gen A6-9220 APU,15
+7th Gen A6-9220C APU,6
+7th Gen A6-9225 APU,15
+7th Gen A6-9500 APU,65
+7th Gen A6-9500E APU,35
+7th Gen A6-9550 APU,65
+7th Gen A8-9600 APU,65
+7th Gen A9-9410 APU,25
+7th Gen A9-9420 APU,15
+7th Gen A9-9425 APU,15
+7th Gen AMD Athlon X4 970,65
+7th Gen AMD PRO A10-9700 APU,65
+7th Gen AMD PRO A10-9700B APU,15
+7th Gen AMD PRO A10-9700E APU,35
+7th Gen AMD PRO A10-9730B APU,35
+7th Gen AMD PRO A12-9800 APU,65
+7th Gen AMD PRO A12-9800B APU,15
+7th Gen AMD PRO A12-9800E APU,35
+7th Gen AMD PRO A12-9830B APU,35
+7th Gen AMD PRO A4-4350B APU,15
+7th Gen AMD PRO A4-5350B APU,15
+7th Gen AMD PRO A6-7350B APU,15
+7th Gen AMD PRO A6-8350B APU,15
+7th Gen AMD PRO A6-9500 APU,65
+7th Gen AMD PRO A6-9500B APU,15
+7th Gen AMD PRO A6-9500E APU,35
+7th Gen AMD PRO A8-9600 APU,65
+7th Gen AMD PRO A8-9600B APU,15
+7th Gen AMD PRO A8-9630B,35
+7th Gen E2-9010 APU,15
+7th Gen FX 9800P APU,15
+7th Gen FX 9830P APU,35
+840,95
+850,95
+860K,95
+860K with Near Silent Thermal Solution,95
+870K with Near Silent Thermal Solution,95
+880K with Near Silent Thermal Solution,95
+960T,95
+965,80
+975,125
+980,125
+A10 Micro-6700T with Radeon R6 Graphics,4.5
+A10 PRO-7350B with Radeon R6 Graphics,19
+A10 PRO-7800B with Radeon R7 Graphics,65
+A10 PRO-7850B with Radeon R7 Graphics,95
+A10-6700 with Radeon HD 8670D,65
+A10-6700T with Radeon HD 8650D,45
+A10-6790B with Radeon HD 8670D,45
+A10-6790K with Radeon HD 8670D,100
+A10-6800B with Radeon HD 8670D,45
+A10-6800K with Radeon HD 8670D,100
+A10-7300 with Radeon R6 Graphics,20
+A10-7400P with Radeon R6 Graphics,35
+A10-7850K with Radeon R7 Series,95
+A10-7860K with Radeon R7 Graphics and Near Silent Thermal Solution,65
+A10-7860K with Radeon R7 Series,65
+A10-7870K with Radeon R7 Graphics and Near Silent Thermal Solution,95
+A10-7870K with Radeon R7 Series,95
+A10-7890K with Radeon R7 Graphics and Wraith cooler,95
+A4 Micro-6400T with Radeon R3 Graphics,4.5
+A4 PRO-3340B with Radeon HD 8240 Graphics,25
+A4 PRO-3350B with Radeon R4 Graphics,15
+A4 PRO-7300B with Radeon HD 8470D,65
+A4 PRO-7350B with Radeon R5 Graphics,65
+A4-5000 with Radeon HD 8330,15
+A4-5100 with Radeon HD 8330,15
+A4-6210 with Radeon R3 Graphics,15
+A4-6300 with Radeon HD 8370D,65
+A4-6320 with Radeon HD 8370D,65
+A4-7210 with Radeon R3 Graphics,65
+A4-7300 with Radeon HD 8470D,65
+A6 PRO-7050B with Radeon R4 Graphics,100
+A6 PRO-7400B with Radeon R5 Graphics,65
+A6-5200 with Radeon HD 8400,25
+A6-5200M with Radeon HD 8400,25
+A6-5350M with Radeon HD 8450G,35
+A6-6310 with Radeon R4 Graphics,15
+A6-6400B with Radeon HD 8470D,65
+A6-6400K with Radeon HD 8470D,65
+A6-6420B with Radeon HD 8470D,65
+A6-6420K with Radeon HD 8470D,65
+A6-7000 with Radeon R4 Graphics,17
+A6-7310 with Radeon R4 Graphics,15
+A6-7400K with Radeon R5 Series,65
+A6-7470K with Radeon R5 Series,65
+A6-8500P with Radeon R5 Graphics,15
+A8 PRO-7150B with Radeon R5 Graphics,100
+A8 PRO-7600B with Radeon R7 Graphics,65
+A8-6410 with Radeon R5 Graphics,15
+A8-6500 with Radeon HD 8570D,65
+A8-6500B with Radeon HD 8570D,65
+A8-6500T with Radeon HD 8550D,45
+A8-6600K with Radeon HD 8570D,65
+A8-7100 with Radeon R5 Graphics,20
+A8-7200P with Radeon R5 Graphics,100
+A8-7410 with Radeon R5 Graphics,15
+A8-7600 with Radeon R7 Series,65
+A8-7650K with Radeon R7 Graphics and Near Silent Thermal Solution,95
+A8-7650K with Radeon R7 Series,95
+A8-7670K with Radeon R7 Graphics and Near Silent Thermal Solution,95
+AMD 3015Ce,6
+AMD 3015e,6
+AMD 3020e,6
 AMD A10-4600M,35
 AMD A10-4655M,25
 AMD A10-5700,65
@@ -90,96 +292,43 @@ AMD A9-9410 SoC,25
 AMD A9-9420 SoC,15
 AMD A9-9425 SoC,15
 AMD Athlon 1000,54
-AMD Athlon 1000,54
 AMD Athlon 1100,60
 AMD Athlon 1133,63
-AMD Athlon 1200,66
 AMD Athlon 1200,66
 AMD Athlon 1300,68
 AMD Athlon 1333,70
 AMD Athlon 1400,72
-AMD Athlon 1400,72
 AMD Athlon 200GE,35
-AMD Athlon 220GE,35
-AMD Athlon 220GE,35
 AMD Athlon 220GE,35
 AMD Athlon 240GE,35
 AMD Athlon 3000G,35
+AMD Athlon 300GE,35
 AMD Athlon 300U,15
+AMD Athlon 320GE,35
 AMD Athlon 600,38
 AMD Athlon 64 1500+,9
 AMD Athlon 64 2000+,8
 AMD Athlon 64 2600+,15
 AMD Athlon 64 2650e,15
 AMD Athlon 64 2700+,32
-AMD Athlon 64 2800+,89
-AMD Athlon 64 2800+,89
 AMD Athlon 64 2800+,32
 AMD Athlon 64 2850e,22
-AMD Athlon 64 3000+,89
-AMD Athlon 64 3000+,51
-AMD Athlon 64 3000+,51
-AMD Athlon 64 3000+,62
-AMD Athlon 64 3000+,67
-AMD Athlon 64 3000+,67
-AMD Athlon 64 3000+,32
-AMD Athlon 64 3000+,89
-AMD Athlon 64 3000+,89
 AMD Athlon 64 3000+,62
 AMD Athlon 64 3100+,25
-AMD Athlon 64 3200+,89
-AMD Athlon 64 3200+,59
-AMD Athlon 64 3200+,67
-AMD Athlon 64 3200+,89
-AMD Athlon 64 3200+,89
-AMD Athlon 64 3200+,67
-AMD Athlon 64 3200+,67
-AMD Athlon 64 3200+,62
-AMD Athlon 64 3200+,45
-AMD Athlon 64 3200+,62
-AMD Athlon 64 3200+,89
 AMD Athlon 64 3200+,83
 AMD Athlon 64 3300+,89
 AMD Athlon 64 3400+,67
-AMD Athlon 64 3400+,89
-AMD Athlon 64 3400+,89
-AMD Athlon 64 3400+,89
-AMD Athlon 64 3400+,89
-AMD Athlon 64 3400+,83
-AMD Athlon 64 3400+,67
-AMD Athlon 64 3500+,67
-AMD Athlon 64 3500+,89
-AMD Athlon 64 3500+,89
-AMD Athlon 64 3500+,62
-AMD Athlon 64 3500+,67
-AMD Athlon 64 3500+,67
-AMD Athlon 64 3500+,45
-AMD Athlon 64 3500+,67
 AMD Athlon 64 3500+,62
 AMD Athlon 64 3500+ (F3),59
 AMD Athlon 64 3500+ EE,35
 AMD Athlon 64 3600+,89
-AMD Athlon 64 3700+,83
 AMD Athlon 64 3700+,89
-AMD Athlon 64 3700+,89
-AMD Athlon 64 3700+,89
-AMD Athlon 64 3800+,62
-AMD Athlon 64 3800+,45
-AMD Athlon 64 3800+,62
-AMD Athlon 64 3800+,89
-AMD Athlon 64 3800+,89
 AMD Athlon 64 3800+,89
 AMD Athlon 64 3800+ (F3),59
-AMD Athlon 64 4000+,62
-AMD Athlon 64 4000+,89
-AMD Athlon 64 4000+,62
-AMD Athlon 64 4000+,89
 AMD Athlon 64 4000+,89
 AMD Athlon 64 4000+ (F3),59
 AMD Athlon 64 FX-51,89
 AMD Athlon 64 FX-53,89
-AMD Athlon 64 FX-53,89
-AMD Athlon 64 FX-55,104
 AMD Athlon 64 FX-55,104
 AMD Athlon 64 FX-57,104
 AMD Athlon 64 FX-60,110
@@ -189,58 +338,34 @@ AMD Athlon 64 FX-72,125
 AMD Athlon 64 FX-74,125
 AMD Athlon 64 FX-76,125
 AMD Athlon 64 LE-1600,45
-AMD Athlon 64 LE-1600,45
 AMD Athlon 64 LE-1620,45
-AMD Athlon 64 LE-1620,45
-AMD Athlon 64 LE-1640,45
-AMD Athlon 64 LE-1640,45
 AMD Athlon 64 LE-1640,45
 AMD Athlon 64 LE-1640B,45
 AMD Athlon 64 LE-1660,45
-AMD Athlon 64 X2 3600+,89
 AMD Athlon 64 X2 3600+,65
 AMD Athlon 64 X2 3600+ EE,65
 AMD Athlon 64 X2 3800+,89
-AMD Athlon 64 X2 3800+,89
-AMD Athlon 64 X2 3800+,89
 AMD Athlon 64 X2 3800+ EE,65
 AMD Athlon 64 X2 3800+ EE SFF,35
-AMD Athlon 64 X2 4000+,89
 AMD Athlon 64 X2 4000+,65
 AMD Athlon 64 X2 4000+ EE,65
 AMD Athlon 64 X2 4200+,89
-AMD Athlon 64 X2 4200+,89
-AMD Athlon 64 X2 4200+,65
-AMD Athlon 64 X2 4200+,89
 AMD Athlon 64 X2 4200+ EE,65
-AMD Athlon 64 X2 4400+,89
-AMD Athlon 64 X2 4400+,110
 AMD Athlon 64 X2 4400+,65
 AMD Athlon 64 X2 4400+ EE,65
-AMD Athlon 64 X2 4600+,110
-AMD Athlon 64 X2 4600+,89
-AMD Athlon 64 X2 4600+,65
 AMD Athlon 64 X2 4600+,89
 AMD Athlon 64 X2 4600+ EE,65
-AMD Athlon 64 X2 4800+,65
-AMD Athlon 64 X2 4800+,110
 AMD Athlon 64 X2 4800+,89
 AMD Athlon 64 X2 4800+ EE,65
-AMD Athlon 64 X2 5000+,65
 AMD Athlon 64 X2 5000+,89
 AMD Athlon 64 X2 5000+ BE,65
 AMD Athlon 64 X2 5000+ EE,65
-AMD Athlon 64 X2 5000+ EE,65
-AMD Athlon 64 X2 5200+,65
 AMD Athlon 64 X2 5200+,89
 AMD Athlon 64 X2 5200+ EE,65
-AMD Athlon 64 X2 5400+,89
 AMD Athlon 64 X2 5400+,65
 AMD Athlon 64 X2 5400+ BE,65
-AMD Athlon 64 X2 5600+,89
 AMD Athlon 64 X2 5600+,65
 AMD Athlon 64 X2 5800+,89
-AMD Athlon 64 X2 6000+,89
 AMD Athlon 64 X2 6000+,125
 AMD Athlon 64 X2 6400+ BE,125
 AMD Athlon 650,38
@@ -250,8 +375,12 @@ AMD Athlon 800,45
 AMD Athlon 850,47
 AMD Athlon 900,50
 AMD Athlon 950,52
+AMD Athlon Gold 3150C,15
 AMD Athlon Gold 3150G,65
+AMD Athlon Gold 3150G (OEM Only),65
 AMD Athlon Gold 3150GE,35
+AMD Athlon Gold 3150GE (OEM Only),35
+AMD Athlon Gold 3150U,15
 AMD Athlon Gold PRO 3150G,65
 AMD Athlon Gold PRO 3150GE,35
 AMD Athlon II X2 210e,45
@@ -300,8 +429,17 @@ AMD Athlon II X4 645,95
 AMD Athlon II X4 651,100
 AMD Athlon II X4 651K,100
 AMD Athlon PRO 200GE,35
+AMD Athlon PRO 200U Mobile Processor with Radeon Vega 3 Graphics,15
+AMD Athlon PRO 300GE,35
 AMD Athlon PRO 300U,15
+AMD Athlon PRO 300U Mobile Processor with Radeon Vega 3 Graphics,15
+AMD Athlon PRO 3045B,15
+AMD Athlon PRO 3145B,15
+AMD Athlon Silver 3050C,15
 AMD Athlon Silver 3050GE,35
+AMD Athlon Silver 3050GE (OEM Only),35
+AMD Athlon Silver 3050U,15
+AMD Athlon Silver 3050e,6
 AMD Athlon Silver PRO 3125GE,35
 AMD Athlon X2 4050e,45
 AMD Athlon X2 4450e,45
@@ -324,49 +462,25 @@ AMD Athlon X4 940,65
 AMD Athlon X4 950,65
 AMD Athlon X4 970,65
 AMD Athlon XP 1500+,60
-AMD Athlon XP 1600+,49
 AMD Athlon XP 1600+,63
-AMD Athlon XP 1700+,64
 AMD Athlon XP 1700+,50
-AMD Athlon XP 1700+,50
-AMD Athlon XP 1800+,66
 AMD Athlon XP 1800+,51
-AMD Athlon XP 1800+,51
-AMD Athlon XP 1900+,68
 AMD Athlon XP 1900+,53
-AMD Athlon XP 2000+,70
 AMD Athlon XP 2000+,60
-AMD Athlon XP 2000+,60
-AMD Athlon XP 2000+,60
-AMD Athlon XP 2000+,60
-AMD Athlon XP 2100+,62
 AMD Athlon XP 2100+,72
 AMD Athlon XP 2200+,63
-AMD Athlon XP 2200+,63
-AMD Athlon XP 2200+,68
-AMD Athlon XP 2200+,63
-AMD Athlon XP 2400+,68
-AMD Athlon XP 2400+,68
-AMD Athlon XP 2400+,68
 AMD Athlon XP 2400+,65
 AMD Athlon XP 2500+,68
 AMD Athlon XP 2500+ DTR,68
 AMD Athlon XP 2600+,68
-AMD Athlon XP 2600+,68
-AMD Athlon XP 2600+,68
-AMD Athlon XP 2600+,68
-AMD Athlon XP 2600+,68
 AMD Athlon XP 2600+ DTR,68
 AMD Athlon XP 2700+,68
-AMD Athlon XP 2800+,68
 AMD Athlon XP 2800+,74
 AMD Athlon XP 2800+ DTR,68
-AMD Athlon XP 3000+,68
 AMD Athlon XP 3000+,68
 AMD Athlon XP 3100+,68
 AMD Athlon XP 3200+,77
 AMD Athlon XP-M 2000+,45
-AMD Athlon XP-M 2200+,45
 AMD Athlon XP-M 2200+,45
 AMD Athlon XP-M 2400+,45
 AMD Athlon XP-M 2500+,45
@@ -408,7 +522,7 @@ AMD EPYC 7343,190
 AMD EPYC 7351,170
 AMD EPYC 7351P,170
 AMD EPYC 7352,155
-AMD EPYC 7371,170
+AMD EPYC 7371,200
 AMD EPYC 73F3,240
 AMD EPYC 7401,170
 AMD EPYC 7401P,170
@@ -425,6 +539,7 @@ AMD EPYC 7501,170
 AMD EPYC 7502,180
 AMD EPYC 7502P,180
 AMD EPYC 7513,200
+AMD EPYC 7532,200
 AMD EPYC 7542,225
 AMD EPYC 7543,225
 AMD EPYC 7543P,225
@@ -445,7 +560,7 @@ AMD EPYC 7742,225
 AMD EPYC 7763,280
 AMD EPYC 7B12,240
 AMD EPYC 7F32,180
-AMD EPYC 7F52,155
+AMD EPYC 7F52,240
 AMD EPYC 7F72,240
 AMD EPYC 7H12,280
 AMD EPYC Embedded 3251,50
@@ -478,73 +593,32 @@ AMD FX-8370E,95
 AMD FX-9370,220
 AMD FX-9590,220
 AMD Mobile Athlon 64 2700+,35
-AMD Mobile Athlon 64 2700+,82
-AMD Mobile Athlon 64 2700+,35
 AMD Mobile Athlon 64 2800+,82
-AMD Mobile Athlon 64 2800+,35
-AMD Mobile Athlon 64 2800+,62
-AMD Mobile Athlon 64 2800+,82
-AMD Mobile Athlon 64 3000+,82
-AMD Mobile Athlon 64 3000+,35
 AMD Mobile Athlon 64 3000+,62
-AMD Mobile Athlon 64 3200+,82
 AMD Mobile Athlon 64 3200+,62
-AMD Mobile Athlon 64 3400+,82
 AMD Mobile Athlon 64 3400+,62
 AMD Mobile Athlon 64 3700+,82
-AMD Opteron 140,82
-AMD Opteron 140,82
 AMD Opteron 140,85
 AMD Opteron 140 EE,30
 AMD Opteron 142,82
-AMD Opteron 142,85
-AMD Opteron 142,82
-AMD Opteron 144,67
-AMD Opteron 144,67
-AMD Opteron 144,85
 AMD Opteron 144,82
-AMD Opteron 144,82
-AMD Opteron 146,67
-AMD Opteron 146,67
-AMD Opteron 146,89
 AMD Opteron 146,67
 AMD Opteron 146 HE,55
-AMD Opteron 148,85
-AMD Opteron 148,89
-AMD Opteron 148,85
 AMD Opteron 148,89
 AMD Opteron 148 HE,55
 AMD Opteron 150,85
-AMD Opteron 150,89
-AMD Opteron 150,85
-AMD Opteron 152,104
 AMD Opteron 152,104
 AMD Opteron 154,104
 AMD Opteron 156,104
 AMD Opteron 2350 HE,79
 AMD Opteron 240,82
-AMD Opteron 240,85
-AMD Opteron 240,82
 AMD Opteron 240 EE,30
-AMD Opteron 242,82
 AMD Opteron 242,85
-AMD Opteron 242,82
-AMD Opteron 242,85
-AMD Opteron 244,82
 AMD Opteron 244,85
-AMD Opteron 244,82
-AMD Opteron 244,85
-AMD Opteron 246,89
-AMD Opteron 246,85
 AMD Opteron 246,85
 AMD Opteron 246 HE,55
-AMD Opteron 246 HE,55
-AMD Opteron 248,89
-AMD Opteron 248,85
-AMD Opteron 248,85
 AMD Opteron 248,89
 AMD Opteron 248 HE,55
-AMD Opteron 250,89
 AMD Opteron 250,85
 AMD Opteron 250 HE,55
 AMD Opteron 252,92
@@ -574,28 +648,14 @@ AMD Opteron 6376,115
 AMD Opteron 6378,115
 AMD Opteron 6380,115
 AMD Opteron 6386 SE,140
-AMD Opteron 840,85
-AMD Opteron 840,82
 AMD Opteron 840,82
 AMD Opteron 840 EE,30
-AMD Opteron 842,85
-AMD Opteron 842,85
 AMD Opteron 842,82
-AMD Opteron 842,82
-AMD Opteron 844,82
-AMD Opteron 844,82
 AMD Opteron 844,85
-AMD Opteron 844,85
-AMD Opteron 846,89
-AMD Opteron 846,85
 AMD Opteron 846,85
 AMD Opteron 846 HE,55
-AMD Opteron 846 HE,55
-AMD Opteron 848,89
-AMD Opteron 848,89
 AMD Opteron 848,85
 AMD Opteron 848 HE,55
-AMD Opteron 850,85
 AMD Opteron 850,89
 AMD Opteron 850 HE,55
 AMD Opteron 852,92
@@ -631,6 +691,7 @@ AMD Opteron X2 880,95
 AMD Opteron X2 885,95
 AMD Opteron X2 890,95
 AMD Opteron X2150,22
+AMD Opteron X2150 APU,22
 AMD Opteron X2170,25
 AMD Phenom II 42 TWKR Black Edition,125
 AMD Phenom II X2 545,80
@@ -676,7 +737,6 @@ AMD Phenom II X4 955 BE,125
 AMD Phenom II X4 960T BE,95
 AMD Phenom II X4 965 BE (125W),125
 AMD Phenom II X4 965 BE (140W),140
-AMD Phenom II X4 970 BE,125
 AMD Phenom II X4 970 BE,125
 AMD Phenom II X4 975 BE,125
 AMD Phenom II X4 980 BE,125
@@ -724,106 +784,177 @@ AMD Ryzen 3 1200,65
 AMD Ryzen 3 1300,65
 AMD Ryzen 3 1300X,65
 AMD Ryzen 3 2200G,65
+AMD Ryzen 3 2200G with Radeon Vega 8 Graphics,65
+AMD Ryzen 3 2200GE with Radeon Vega 8 Graphics,35
 AMD Ryzen 3 2200U,15
 AMD Ryzen 3 2300U,15
 AMD Ryzen 3 2300X,65
 AMD Ryzen 3 3100,65
 AMD Ryzen 3 3200G,65
+AMD Ryzen 3 3200G with Radeon Vega 8 Graphics,65
+AMD Ryzen 3 3200GE (OEM Only),35
 AMD Ryzen 3 3200U,15
+AMD Ryzen 3 3250C,15
 AMD Ryzen 3 3250U,15
 AMD Ryzen 3 3300U,15
 AMD Ryzen 3 3300X,65
+AMD Ryzen 3 3350U,15
 AMD Ryzen 3 4300G,65
+AMD Ryzen 3 4300G (OEM Only),65
 AMD Ryzen 3 4300GE,35
+AMD Ryzen 3 4300GE (OEM Only),35
 AMD Ryzen 3 4300U,25
+AMD Ryzen 3 5300G (OEM Only),65
+AMD Ryzen 3 5300GE (OEM Only),35
+AMD Ryzen 3 5300U,15
+AMD Ryzen 3 5400U,15
 AMD Ryzen 3 PRO 1200,65
 AMD Ryzen 3 PRO 1300,65
+AMD Ryzen 3 PRO 2200G with Radeon Vega 8 Graphics,65
+AMD Ryzen 3 PRO 2200GE with Radeon Vega 8 Graphics,35
 AMD Ryzen 3 PRO 2300U,15
+AMD Ryzen 3 PRO 3200G,65
+AMD Ryzen 3 PRO 3200GE,35
 AMD Ryzen 3 PRO 3300U,15
 AMD Ryzen 3 PRO 4350G,65
 AMD Ryzen 3 PRO 4350GE,35
+AMD Ryzen 3 PRO 4450U,15
+AMD Ryzen 3 PRO 5350G,65
+AMD Ryzen 3 PRO 5350GE,35
+AMD Ryzen 3 PRO 5450U,15
 AMD Ryzen 5 1400,65
 AMD Ryzen 5 1500X,65
 AMD Ryzen 5 1600,65
+AMD Ryzen 5 1600 (AF),65
 AMD Ryzen 5 1600X,95
 AMD Ryzen 5 2400G,65
+AMD Ryzen 5 2400G with Radeon RX Vega 11 Graphics,65
+AMD Ryzen 5 2400GE with Radeon RX Vega 11 Graphics,35
 AMD Ryzen 5 2500U,15
 AMD Ryzen 5 2500X,65
 AMD Ryzen 5 2600,65
-AMD Ryzen 5 2600E,65
-AMD Ryzen 5 2600H,15
+AMD Ryzen 5 2600E,45
+AMD Ryzen 5 2600H,45
 AMD Ryzen 5 2600X,95
 AMD Ryzen 5 3400G,65
+AMD Ryzen 5 3400G with Radeon RX Vega 11 Graphics,65
+AMD Ryzen 5 3400GE (OEM Only),35
+AMD Ryzen 5 3450U,15
+AMD Ryzen 5 3500 Processor (OEM Only),65
+AMD Ryzen 5 3500C,15
 AMD Ryzen 5 3500U,15
 AMD Ryzen 5 3500X,65
 AMD Ryzen 5 3550H,35
 AMD Ryzen 5 3580U,15
+AMD Ryzen 5 3580U Microsoft Surface® Edition,15
 AMD Ryzen 5 3600,65
 AMD Ryzen 5 3600X,95
 AMD Ryzen 5 3600XT,95
 AMD Ryzen 5 4500U,25
 AMD Ryzen 5 4600G,65
+AMD Ryzen 5 4600G (OEM Only),65
 AMD Ryzen 5 4600GE,35
+AMD Ryzen 5 4600GE (OEM Only),35
 AMD Ryzen 5 4600H,54
 AMD Ryzen 5 4600HS,35
 AMD Ryzen 5 4600U,25
+AMD Ryzen 5 4680U Microsoft Surface® Edition,15
 AMD Ryzen 5 5500U,25
+AMD Ryzen 5 5600G,65
+AMD Ryzen 5 5600GE,35
+AMD Ryzen 5 5600H,45
+AMD Ryzen 5 5600HS,35
+AMD Ryzen 5 5600U,15
 AMD Ryzen 5 5600X,65
 AMD Ryzen 5 PRO 1500,65
 AMD Ryzen 5 PRO 1600,65
 AMD Ryzen 5 PRO 2400G,65
+AMD Ryzen 5 PRO 2400G with Radeon Vega 11 Graphics,65
+AMD Ryzen 5 PRO 2400GE with Radeon Vega 11 Graphics,35
 AMD Ryzen 5 PRO 2500U,15
 AMD Ryzen 5 PRO 2600,65
+AMD Ryzen 5 PRO 3350G,65
+AMD Ryzen 5 PRO 3350GE,35
+AMD Ryzen 5 PRO 3400G,65
+AMD Ryzen 5 PRO 3400GE,35
 AMD Ryzen 5 PRO 3500U,15
+AMD Ryzen 5 PRO 3600,65
 AMD Ryzen 5 PRO 4650G,65
 AMD Ryzen 5 PRO 4650GE,35
+AMD Ryzen 5 PRO 4650U,15
+AMD Ryzen 5 PRO 5650G,65
+AMD Ryzen 5 PRO 5650GE,35
+AMD Ryzen 5 PRO 5650U,15
 AMD Ryzen 7 1700,65
+AMD Ryzen 7 1700 Processor,65
 AMD Ryzen 7 1700X,95
 AMD Ryzen 7 1800X,95
 AMD Ryzen 7 2700,65
 AMD Ryzen 7 2700E,65
+AMD Ryzen 7 2700E Processor,45
 AMD Ryzen 7 2700U,15
 AMD Ryzen 7 2700X,105
 AMD Ryzen 7 2700X 50th Anniversary,105
-AMD Ryzen 7 2800H,15
+AMD Ryzen 7 2800H,45
+AMD Ryzen 7 3700C,15
 AMD Ryzen 7 3700U,15
 AMD Ryzen 7 3700X,65
 AMD Ryzen 7 3750H,35
 AMD Ryzen 7 3780U,15
+AMD Ryzen 7 3780U Microsoft Surface® Edition,15
 AMD Ryzen 7 3800X,105
 AMD Ryzen 7 3800XT,105
 AMD Ryzen 7 4700G,65
+AMD Ryzen 7 4700G (OEM Only),65
 AMD Ryzen 7 4700GE,35
+AMD Ryzen 7 4700GE (OEM Only),35
 AMD Ryzen 7 4700U,25
 AMD Ryzen 7 4800H,54
 AMD Ryzen 7 4800HS,35
 AMD Ryzen 7 4800U,25
+AMD Ryzen 7 4980U Microsoft Surface® Edition,15
+AMD Ryzen 7 5700G,65
+AMD Ryzen 7 5700GE,35
+AMD Ryzen 7 5700U,15
+AMD Ryzen 7 5800 (OEM Only),65
 AMD Ryzen 7 5800H,54
 AMD Ryzen 7 5800HS,35
+AMD Ryzen 7 5800U,15
 AMD Ryzen 7 5800X,105
 AMD Ryzen 7 PRO 1700,65
 AMD Ryzen 7 PRO 1700X,95
+AMD Ryzen 7 PRO 1700X Processor,95
 AMD Ryzen 7 PRO 2700,65
 AMD Ryzen 7 PRO 2700U,15
 AMD Ryzen 7 PRO 2700X,95
+AMD Ryzen 7 PRO 3700,65
 AMD Ryzen 7 PRO 3700U,15
 AMD Ryzen 7 PRO 4750G,65
 AMD Ryzen 7 PRO 4750GE,35
+AMD Ryzen 7 PRO 4750U,15
+AMD Ryzen 7 PRO 5750G,65
+AMD Ryzen 7 PRO 5750GE,35
+AMD Ryzen 7 PRO 5850U,15
+AMD Ryzen 9 3900 Processor (OEM Only),65
 AMD Ryzen 9 3900X,105
 AMD Ryzen 9 3900XT,105
 AMD Ryzen 9 3950X,105
 AMD Ryzen 9 4900H,54
 AMD Ryzen 9 4900HS,35
+AMD Ryzen 9 5900 (OEM Only),65
+AMD Ryzen 9 5900HS,35
 AMD Ryzen 9 5900HX,45
 AMD Ryzen 9 5900X,105
 AMD Ryzen 9 5950X,105
 AMD Ryzen 9 5980HS,35
+AMD Ryzen 9 5980HX,45
+AMD Ryzen 9 PRO 3900,65
 AMD Ryzen Embedded V1202B,15
 AMD Ryzen Embedded V1605B,15
 AMD Ryzen Embedded V1756B,45
 AMD Ryzen Embedded V1807B,45
 AMD Ryzen Threadripper 1900,125
-AMD Ryzen Threadripper 1900X,125
+AMD Ryzen Threadripper 1900X,180
 AMD Ryzen Threadripper 1920,140
 AMD Ryzen Threadripper 1920X,180
 AMD Ryzen Threadripper 1940,180
@@ -853,67 +984,21 @@ AMD Sempron 145,45
 AMD Sempron 150,45
 AMD Sempron 180,45
 AMD Sempron 2200+,62
-AMD Sempron 2200+,62
-AMD Sempron 2200+,62
-AMD Sempron 2300+,62
 AMD Sempron 2300+,62
 AMD Sempron 2400+,62
-AMD Sempron 2400+,62
-AMD Sempron 2400+,62
-AMD Sempron 2500+,62
-AMD Sempron 2500+,62
 AMD Sempron 2500+,62
 AMD Sempron 2600+,62
-AMD Sempron 2600+,25
-AMD Sempron 2600+,25
-AMD Sempron 2600+,62
-AMD Sempron 2600+,62
-AMD Sempron 2600+,62
 AMD Sempron 2800+,62
-AMD Sempron 2800+,25
-AMD Sempron 2800+,62
-AMD Sempron 2800+,62
-AMD Sempron 2800+,25
-AMD Sempron 2800+,62
-AMD Sempron 2800+,25
-AMD Sempron 2800+,62
-AMD Sempron 2800+,62
-AMD Sempron 3000+,25
-AMD Sempron 3000+,62
-AMD Sempron 3000+,62
-AMD Sempron 3000+,62
-AMD Sempron 3000+,25
-AMD Sempron 3000+,62
-AMD Sempron 3000+,25
-AMD Sempron 3000+,62
-AMD Sempron 3000+,62
 AMD Sempron 3000+,62
 AMD Sempron 3000+ EE SFF,35
-AMD Sempron 3100+,62
-AMD Sempron 3100+,62
-AMD Sempron 3100+,62
-AMD Sempron 3100+,62
 AMD Sempron 3100+,25
-AMD Sempron 3100+,25
-AMD Sempron 3100+,25
-AMD Sempron 3200+,62
 AMD Sempron 3200+,62
 AMD Sempron 3200+ EE SFF,35
 AMD Sempron 3300+,62
-AMD Sempron 3300+,25
-AMD Sempron 3300+,62
-AMD Sempron 3300+,62
-AMD Sempron 3300+,62
-AMD Sempron 3400+,62
-AMD Sempron 3400+,62
-AMD Sempron 3400+,25
-AMD Sempron 3400+,62
 AMD Sempron 3400+,62
 AMD Sempron 3400+ EE SFF,35
 AMD Sempron 3500+,62
-AMD Sempron 3500+,62
 AMD Sempron 3500+ EE SFF,35
-AMD Sempron 3600+,62
 AMD Sempron 3600+,62
 AMD Sempron 3800+,62
 AMD Sempron LE-1100,45
@@ -921,7 +1006,6 @@ AMD Sempron LE-1150,45
 AMD Sempron LE-1200,45
 AMD Sempron LE-1250,45
 AMD Sempron LE-1300,45
-AMD Sempron X2 2100,65
 AMD Sempron X2 2100,65
 AMD Sempron X2 2200,65
 AMD Sempron X2 2300,65
@@ -954,124 +1038,355 @@ AMD Turion X2 Ultra ZM-88,35
 AMD Z-01,6
 AMD Z-60,5
 Apple M1,10
+Athlon 5150 APU with Radeon R3 Series,25
+Athlon 5350 APU with Radeon R3 Series,25
+Athlon 5370 APU with Radeon R3 Series,25
+B57,80
+B59,80
+B60,80
+B75,95
+B77,95
+B97,95
+B99,95
+E1 Micro-6200T with Radeon R2 Graphics,3.95
+E1-2100 with Radeon HD 8210,9
+E1-2200 with Radeon HD 8210,9
+E1-2500 with Radeon HD 8240,15
+E1-6010 with Radeon R2 Graphics,10
+E1-7010 with Radeon R2 Graphics,10
+E2-3000 with Radeon HD 8280,15
+E2-3800 with Radeon HD 8280,15
+E2-6110 with Radeon R2 Graphics,15
+E2-7110 with Radeon R2 Graphics,65
+FX 6100,95
+FX-4100,95
+FX-4130,125
+FX-4170,125
+FX-4300,95
+FX-4320,95
+FX-4350,125
+FX-6200,125
+FX-6300,95
+FX-6350,125
+FX-6350 with Wraith cooler,125
+FX-7500 with Radeon R7 Graphics,20
+FX-7600P with Radeon R7 Graphics,35
+FX-8120,125
+FX-8150,125
+FX-8300,95
+FX-8310,95
+FX-8320,125
+FX-8320E,95
+FX-8350,125
+FX-8350 with Wraith cooler,125
+FX-8370,125
+FX-8370 with Wraith cooler,125
+FX-8370E,95
+FX-9370,220
+FX-9590,220
 Intel A100,3
 Intel A110,3
 Intel Atom 230,4
 Intel Atom 330,8
+Intel Atom C2308,6
+Intel Atom C2316,7
+Intel Atom C2338,7
+Intel Atom C2350,6
+Intel Atom C2358,7
+Intel Atom C2508,9.5
+Intel Atom C2516,10
+Intel Atom C2518,13
+Intel Atom C2530,9
+Intel Atom C2538,15
+Intel Atom C2550,14
+Intel Atom C2558,15
+Intel Atom C2718,18
+Intel Atom C2730,12
+Intel Atom C2738,20
+Intel Atom C2750,20
+Intel Atom C2758,20
+Intel Atom C3308,9.5
+Intel Atom C3336,11
+Intel Atom C3338,8.5
+Intel Atom C3338R,10.5
+Intel Atom C3436L,10.75
+Intel Atom C3508,11.5
+Intel Atom C3538,15
+Intel Atom C3558,16
+Intel Atom C3558R,17
+Intel Atom C3708,17
+Intel Atom C3750,21
+Intel Atom C3758,25
+Intel Atom C3758R,26
+Intel Atom C3808,25
+Intel Atom C3830,21
+Intel Atom C3850,25
+Intel Atom C3858,25
+Intel Atom C3950,24
+Intel Atom C3955,32
+Intel Atom C3958,31
 Intel Atom CE4100,7
+Intel Atom CE4110,7
 Intel Atom CE4130,7
 Intel Atom CE4150,7
+Intel Atom CE4215,7
+Intel Atom CE4235,7
+Intel Atom CE4253,7
+Intel Atom CE4255,7
+Intel Atom CE4257,7
+Intel Atom CE4270,7
+Intel Atom CE4275,7
+Intel Atom CE4277,7
+Intel Atom CE5315,15
 Intel Atom D2500,10
 Intel Atom D2550,10
+Intel Atom D2560,10
 Intel Atom D2700,10
+Intel Atom D2701,10
 Intel Atom D410,10
 Intel Atom D425,10
 Intel Atom D510,13
 Intel Atom D525,13
+Intel Atom E3805,3
 Intel Atom E3815,5
 Intel Atom E3825,6
 Intel Atom E3826,7
 Intel Atom E3827,8
 Intel Atom E3845,10
-Intel Atom E620,3
-Intel Atom E620T,3
-Intel Atom E625C,3
+Intel Atom E620,3.3
+Intel Atom E620T,3.3
+Intel Atom E625C,2.7
 Intel Atom E625CT,3
-Intel Atom E640,3
-Intel Atom E640T,3
-Intel Atom E645C,4
+Intel Atom E640,3.6
+Intel Atom E640T,3.6
+Intel Atom E645C,3.6
 Intel Atom E645CT,4
-Intel Atom E660,3
-Intel Atom E660T,3
-Intel Atom E665C,4
+Intel Atom E660,3.6
+Intel Atom E660T,3.6
+Intel Atom E665C,3.6
 Intel Atom E665CT,7
-Intel Atom E680,4
-Intel Atom E680T,4
-Intel Atom N2600,4
-Intel Atom N270,3
-Intel Atom N280,3
-Intel Atom N2800,7
-Intel Atom N450,6
-Intel Atom N455,7
-Intel Atom N470,7
-Intel Atom N475,7
-Intel Atom N550,9
-Intel Atom N570,9
-Intel Atom S1220,8
-Intel Atom S1240,6
-Intel Atom S1260,9
+Intel Atom E680,4.5
+Intel Atom E680T,4.5
+Intel Atom N2600,3.5
+Intel Atom N270,2.5
+Intel Atom N280,2.5
+Intel Atom N2800,6.5
+Intel Atom N435,5.0
+Intel Atom N450,5.5
+Intel Atom N455,6.5
+Intel Atom N470,6.5
+Intel Atom N475,6.5
+Intel Atom N550,8.5
+Intel Atom N570,8.5
+Intel Atom S1220,8.1
+Intel Atom S1240,6.1
+Intel Atom S1260,8.5
+Intel Atom S1269,11.7
+Intel Atom S1279,13.1
+Intel Atom S1289,14.1
+Intel Atom Z2420,3
+Intel Atom Z2460,3
+Intel Atom Z2480,4
+Intel Atom Z2610,3
 Intel Atom Z2760,3
 Intel Atom Z3740,2
 Intel Atom Z3770,8
-Intel Atom Z500,1
+Intel Atom Z500,0.65
 Intel Atom Z510,2
-Intel Atom Z510P,2
-Intel Atom Z510PT,2
-Intel Atom Z515,1
+Intel Atom Z510P,2.2
+Intel Atom Z510PT,2.2
+Intel Atom Z515,1.4
 Intel Atom Z520,2
-Intel Atom Z520PT,2
+Intel Atom Z520PT,2.2
 Intel Atom Z530,2
-Intel Atom Z530P,2
-Intel Atom Z540,2
-Intel Atom Z550,2
-Intel Atom Z560,2
-Intel Atom Z600,1
-Intel Atom Z605,2
-Intel Atom Z610,1
-Intel Atom Z612,1
-Intel Atom Z615,2
-Intel Atom Z620,1
-Intel Atom Z625,2
+Intel Atom Z530P,2.2
+Intel Atom Z540,2.4
+Intel Atom Z550,2.4
+Intel Atom Z560,2.5
+Intel Atom Z600,1.3
+Intel Atom Z605,2.2
+Intel Atom Z610,1.3
+Intel Atom Z612,1.3
+Intel Atom Z615,2.2
+Intel Atom Z620,1.3
+Intel Atom Z625,2.2
 Intel Atom Z650,3
 Intel Atom Z670,3
+Intel Atom x5-E3930,6.5
+Intel Atom x5-E3940,9.5
+Intel Atom x5-E8000,5
+Intel Atom x5-Z8300,2.17
+Intel Atom x5-Z8330,2.17
+Intel Atom x5-Z8350,2.17
+Intel Atom x5-Z8500,2.17
+Intel Atom x5-Z8550,2.17
+Intel Atom x6200FE,4.5
+Intel Atom x6211E,6
+Intel Atom x6212RE,6
+Intel Atom x6413E,9
+Intel Atom x6414RE,9
+Intel Atom x6425E,12
+Intel Atom x6425RE,12
+Intel Atom x6427FE,12
+Intel Atom x7-E3950,12
+Intel Atom x7-Z8700,2.17
+Intel Atom x7-Z8750,2.17
+Intel Atom E625CT,2.7
+Intel Atom E645CT,3.6
+Intel Atom E665CT,3.6
 Intel Aubrey Isle,300
-Intel Celeron 2.0,73
-Intel Celeron 2.0,73
+Intel Celeron 1.00,29
+Intel Celeron 1.10,33
+Intel Celeron 1.5,60
+Intel Celeron 1.66,27
+Intel Celeron 1.7,63.5
+Intel Celeron 1.8,66.1
+Intel Celeron 1.83,27
+Intel Celeron 1000A,27.29.5
+Intel Celeron 1000M,35
+Intel Celeron 1005M,35
+Intel Celeron 1007U,17
+Intel Celeron 1017U,17
+Intel Celeron 1019Y,10
+Intel Celeron 1020E,35
+Intel Celeron 1020M,35
+Intel Celeron 1037U,17
+Intel Celeron 1047UE,17
+Intel Celeron 1100A,27.29.5
+Intel Celeron 1200,29.32.9
+Intel Celeron 1300,33.4
+Intel Celeron 1400,33.34.8
+Intel Celeron 2.0,52.8
+Intel Celeron 2.1,55.5
 Intel Celeron 2.10,73
+Intel Celeron 2.2,57.1
 Intel Celeron 2.20,73
+Intel Celeron 2.3,58.3
 Intel Celeron 2.30,73
+Intel Celeron 2.4,59.8
 Intel Celeron 2.40,73
+Intel Celeron 2.5,61.0
+Intel Celeron 2.6,62.6
 Intel Celeron 2.60,73
+Intel Celeron 2.7,66.8
 Intel Celeron 2.70,73
+Intel Celeron 2.8,68.4
 Intel Celeron 2.80,73
+Intel Celeron 2000E,37
+Intel Celeron 2002E,25
+Intel Celeron 205,21
+Intel Celeron 215,27
 Intel Celeron 220,19
-Intel Celeron 2950M,37
+Intel Celeron 266,16.59
 Intel Celeron 2950M,37
 Intel Celeron 2955U,15
-Intel Celeron 2955U,15
-Intel Celeron 2961Y,12
+Intel Celeron 2957U,15
+Intel Celeron 2961Y,11.5
+Intel Celeron 2970M,37
 Intel Celeron 2980U,15
+Intel Celeron 2981U,15
+Intel Celeron 300,18.48
+Intel Celeron 300A,17.8
 Intel Celeron 3205U,15
+Intel Celeron 3215U,15
+Intel Celeron 333,19.7
+Intel Celeron 366,21.7
 Intel Celeron 3755U,15
+Intel Celeron 3765U,15
+Intel Celeron 3855U,15
+Intel Celeron 3865U,15
+Intel Celeron 3867U,15
+Intel Celeron 3955U,15
+Intel Celeron 3965U,15
+Intel Celeron 3965Y,6
+Intel Celeron 400,23.7
 Intel Celeron 420,35
+Intel Celeron 4205U,15
 Intel Celeron 430,35
+Intel Celeron 4305U,15
+Intel Celeron 4305UE,15
+Intel Celeron 433,24.1
 Intel Celeron 440,35
 Intel Celeron 445,65
 Intel Celeron 450,35
+Intel Celeron 466,25.7
+Intel Celeron 500,27
+Intel Celeron 5205U,15
+Intel Celeron 530,27
+Intel Celeron 5305U,15
+Intel Celeron 533,28.3
+Intel Celeron 533A,14
+Intel Celeron 540,30
+Intel Celeron 550,30
+Intel Celeron 560,27
+Intel Celeron 566,19.2
+Intel Celeron 570,27
+Intel Celeron 575,31
+Intel Celeron 585,31
+Intel Celeron 600,15.8
+Intel Celeron 6305,15
+Intel Celeron 6305E,15
+Intel Celeron 633,16.5
+Intel Celeron 6600HE,35
+Intel Celeron 667,17.5
+Intel Celeron 700,18.3
 Intel Celeron 725C,17
+Intel Celeron 733,23.6
+Intel Celeron 766,20
 Intel Celeron 787,17
+Intel Celeron 797,17
+Intel Celeron 800,20.8
 Intel Celeron 807,17
+Intel Celeron 807UE,10
+Intel Celeron 827E,17
 Intel Celeron 847,17
+Intel Celeron 847E,17
+Intel Celeron 850,25.7
 Intel Celeron 857,17
+Intel Celeron 867,17
 Intel Celeron 877,17
 Intel Celeron 887,17
+Intel Celeron 900,35
+Intel Celeron 925,35
+Intel Celeron 927UE,17
+Intel Celeron 950,28
 Intel Celeron B710,35
+Intel Celeron B720,35
 Intel Celeron B730,35
 Intel Celeron B800,35
 Intel Celeron B810,35
+Intel Celeron B810E,35
+Intel Celeron B815,35
 Intel Celeron B820,35
 Intel Celeron B830,35
 Intel Celeron B840,35
+Intel Celeron D 310,73
+Intel Celeron D 315,73
+Intel Celeron D 320,73
 Intel Celeron D 325,73
+Intel Celeron D 325J,84
 Intel Celeron D 326,73
 Intel Celeron D 330,84
+Intel Celeron D 330J,84
+Intel Celeron D 331,84
 Intel Celeron D 335,84
-Intel Celeron D 335,84
+Intel Celeron D 335J,84
+Intel Celeron D 336,84
 Intel Celeron D 340,84
+Intel Celeron D 340J,84
 Intel Celeron D 341,84
+Intel Celeron D 345,73
+Intel Celeron D 345J,84
 Intel Celeron D 346,73
+Intel Celeron D 347,65
 Intel Celeron D 350,84
+Intel Celeron D 350J,73
+Intel Celeron D 351,84
 Intel Celeron D 352,84
+Intel Celeron D 355,84
+Intel Celeron D 356,65
+Intel Celeron D 360,65
+Intel Celeron D 365,65
 Intel Celeron E1200,65
 Intel Celeron E1400,65
 Intel Celeron E1500,65
@@ -1094,15 +1409,28 @@ Intel Celeron G1840,54
 Intel Celeron G1840T,54
 Intel Celeron G1850,54
 Intel Celeron G3900,51
+Intel Celeron G3900E,35
+Intel Celeron G3900T,35
+Intel Celeron G3900TE,35
+Intel Celeron G3902E,25
 Intel Celeron G3920,51
 Intel Celeron G3930,51
+Intel Celeron G3930E,54
 Intel Celeron G3930T,35
+Intel Celeron G3930TE,35
 Intel Celeron G3950,51
 Intel Celeron G440,35
 Intel Celeron G460,35
 Intel Celeron G465,35
+Intel Celeron G470,35
 Intel Celeron G4900,51
+Intel Celeron G4900T,35
 Intel Celeron G4920,51
+Intel Celeron G4930,54
+Intel Celeron G4930E,35
+Intel Celeron G4930T,35
+Intel Celeron G4932E,25
+Intel Celeron G4950,54
 Intel Celeron G530,65
 Intel Celeron G530T,35
 Intel Celeron G540,65
@@ -1111,29 +1439,117 @@ Intel Celeron G550,65
 Intel Celeron G550T,35
 Intel Celeron G555,65
 Intel Celeron G5900,58
+Intel Celeron G5900E,58
+Intel Celeron G5900T,35
+Intel Celeron G5900TE,35
+Intel Celeron G5905,58
+Intel Celeron G5905T,35
 Intel Celeron G5920,58
-Intel Celeron N2805,4
-Intel Celeron N2806,4
-Intel Celeron N2807,4
-Intel Celeron N2808,4
-Intel Celeron N2810,7
-Intel Celeron N2820,7
-Intel Celeron N2830,7
-Intel Celeron N2840,7
-Intel Celeron N2910,7
-Intel Celeron N2920,7
-Intel Celeron N2930,7
-Intel Celeron N2940,7
+Intel Celeron G5925,58
+Intel Celeron J1750,10
+Intel Celeron J1800,10
+Intel Celeron J1850,10
+Intel Celeron J1900,10
+Intel Celeron J3060,6
+Intel Celeron J3160,6
+Intel Celeron J3355,10
+Intel Celeron J3455,10
+Intel Celeron J4005,10
+Intel Celeron J4025,10
+Intel Celeron J4105,10
+Intel Celeron J4125,10
+Intel Celeron J6412,10
+Intel Celeron J6413,10
+Intel Celeron M 310,24.5
+Intel Celeron M 320,24.5
+Intel Celeron M 330,24.5
+Intel Celeron M 340,24.5
+Intel Celeron M 350,21
+Intel Celeron M 360,21
+Intel Celeron M 370,21
+Intel Celeron M 380,21
+Intel Celeron M 390,21
+Intel Celeron M 410,27
+Intel Celeron M 420,27
+Intel Celeron M 430,27
+Intel Celeron M 440,27
+Intel Celeron M 450,27
+Intel Celeron M 520,30
+Intel Celeron M 530,30
+Intel Celeron M ULV 333,7
+Intel Celeron M ULV 353,5
+Intel Celeron M ULV 373,5.5
+Intel Celeron M ULV 383,5.5
+Intel Celeron M ULV 423,5.5
+Intel Celeron M ULV 443,5.5
+Intel Celeron M ULV 523,5.5
+Intel Celeron M ULV 600,7
+Intel Celeron M ULV 722,5.5
+Intel Celeron M ULV 723,10
+Intel Celeron M ULV 743,10
+Intel Celeron M ULV 800,7
+Intel Celeron N2805,4.3
+Intel Celeron N2806,4.5
+Intel Celeron N2807,4.3
+Intel Celeron N2808,4.5
+Intel Celeron N2810,7.5
+Intel Celeron N2815,7.5
+Intel Celeron N2820,7.5
+Intel Celeron N2830,7.5
+Intel Celeron N2840,7.5
+Intel Celeron N2910,7.5
+Intel Celeron N2920,7.5
+Intel Celeron N2930,7.5
+Intel Celeron N2940,7.5
+Intel Celeron N3000,4
+Intel Celeron N3010,4
+Intel Celeron N3050,6
+Intel Celeron N3060,6
+Intel Celeron N3150,6
+Intel Celeron N3160,6
+Intel Celeron N3350,6
+Intel Celeron N3450,6
+Intel Celeron N4000,6
+Intel Celeron N4020,6
+Intel Celeron N4100,6
+Intel Celeron N4120,6
+Intel Celeron N4500,6
+Intel Celeron N4505,10
+Intel Celeron N5100,6
+Intel Celeron N5105,10
+Intel Celeron N6210,6.5
+Intel Celeron N6211,6.5
 Intel Celeron P1053,30
+Intel Celeron P4500,35
+Intel Celeron P4505,35
+Intel Celeron P4600,35
+Intel Celeron SU2300,10
+Intel Celeron T1400,35
+Intel Celeron T1500,35
+Intel Celeron T1600,35
+Intel Celeron T1700,35
+Intel Celeron T3000,35
+Intel Celeron T3100,35
+Intel Celeron T3300,35
+Intel Celeron T3500,35
+Intel Celeron U3400,18
+Intel Celeron U3405,18
+Intel Celeron U3600,18
+Intel Celeron ULV 573,10
+Intel Celeron ULV 763,10
+Intel Celeron 1.8A,66.1
 Intel Core 2 Duo E4300,65
 Intel Core 2 Duo E4400,65
 Intel Core 2 Duo E4500,65
 Intel Core 2 Duo E4600,65
 Intel Core 2 Duo E4700,65
 Intel Core 2 Duo E6300,65
+Intel Core 2 Duo E6305,65
 Intel Core 2 Duo E6320,65
 Intel Core 2 Duo E6400,65
+Intel Core 2 Duo E6405,65
 Intel Core 2 Duo E6420,65
+Intel Core 2 Duo E6540,65
 Intel Core 2 Duo E6550,65
 Intel Core 2 Duo E6600,65
 Intel Core 2 Duo E6700,65
@@ -1144,15 +1560,71 @@ Intel Core 2 Duo E7300,65
 Intel Core 2 Duo E7400,65
 Intel Core 2 Duo E7500,65
 Intel Core 2 Duo E7600,65
+Intel Core 2 Duo E8135,35
 Intel Core 2 Duo E8190,65
 Intel Core 2 Duo E8200,65
+Intel Core 2 Duo E8235,44
+Intel Core 2 Duo E8290,65
 Intel Core 2 Duo E8300,65
+Intel Core 2 Duo E8335,35
 Intel Core 2 Duo E8400,65
+Intel Core 2 Duo E8435,44
 Intel Core 2 Duo E8500,65
 Intel Core 2 Duo E8600,65
+Intel Core 2 Duo E8700,65
+Intel Core 2 Duo L7200,17
+Intel Core 2 Duo L7300,17
+Intel Core 2 Duo L7400,17
+Intel Core 2 Duo L7500,17
+Intel Core 2 Duo L7700,17
+Intel Core 2 Duo P7350,25
+Intel Core 2 Duo P7370,25
+Intel Core 2 Duo P7450,25
+Intel Core 2 Duo P7550,25
+Intel Core 2 Duo P7570,25
+Intel Core 2 Duo P8400,25
+Intel Core 2 Duo P8600,25
+Intel Core 2 Duo P8700,25
+Intel Core 2 Duo P8800,25
+Intel Core 2 Duo P9500,25
+Intel Core 2 Duo P9600,25
+Intel Core 2 Duo P9700,28
+Intel Core 2 Duo SL7100,12
+Intel Core 2 Duo SL9300,17
+Intel Core 2 Duo SL9380,17
+Intel Core 2 Duo SL9400,17
+Intel Core 2 Duo SL9600,17
+Intel Core 2 Duo SP7500,20
+Intel Core 2 Duo SP7700,20
+Intel Core 2 Duo SP9300,25
+Intel Core 2 Duo SP9400,25
+Intel Core 2 Duo SP9600,25
+Intel Core 2 Duo SU7300,10
+Intel Core 2 Duo SU9300,10
+Intel Core 2 Duo SU9400,10
+Intel Core 2 Duo SU9600,10
 Intel Core 2 Duo T5200,35
+Intel Core 2 Duo T5250,35
+Intel Core 2 Duo T5270,35
+Intel Core 2 Duo T5300,34
+Intel Core 2 Duo T5450,35
+Intel Core 2 Duo T5470,35
 Intel Core 2 Duo T5500,35
+Intel Core 2 Duo T5550,35
 Intel Core 2 Duo T5600,35
+Intel Core 2 Duo T5670,35
+Intel Core 2 Duo T5750,35
+Intel Core 2 Duo T5800,35
+Intel Core 2 Duo T5850,35
+Intel Core 2 Duo T5870,35
+Intel Core 2 Duo T5900,35
+Intel Core 2 Duo T6400,35
+Intel Core 2 Duo T6500,35
+Intel Core 2 Duo T6570,35
+Intel Core 2 Duo T6600,35
+Intel Core 2 Duo T6670,35
+Intel Core 2 Duo T6900,35
+Intel Core 2 Duo T6970,35
 Intel Core 2 Duo T7100,35
 Intel Core 2 Duo T7200,35
 Intel Core 2 Duo T7250,35
@@ -1163,22 +1635,33 @@ Intel Core 2 Duo T7600,35
 Intel Core 2 Duo T7600G,35
 Intel Core 2 Duo T7700,35
 Intel Core 2 Duo T7800,35
-Intel Core 2 Duo U7500,10
+Intel Core 2 Duo T8100,35
+Intel Core 2 Duo T8300,35
+Intel Core 2 Duo T9300,35
+Intel Core 2 Duo T9400,35
+Intel Core 2 Duo T9500,35
+Intel Core 2 Duo T9550,35
+Intel Core 2 Duo T9600,35
+Intel Core 2 Duo T9800,35
+Intel Core 2 Duo T9900,35
 Intel Core 2 Duo U7500,10
 Intel Core 2 Duo U7600,10
-Intel Core 2 Duo U7600,10
-Intel Core 2 Duo U7700,10
 Intel Core 2 Duo U7700,10
 Intel Core 2 Extreme QX6700,130
 Intel Core 2 Extreme QX6800,130
 Intel Core 2 Extreme QX6850,130
 Intel Core 2 Extreme QX9300,45
 Intel Core 2 Extreme QX9650,130
+Intel Core 2 Extreme QX9750,130
 Intel Core 2 Extreme QX9770,136
 Intel Core 2 Extreme QX9775,150
 Intel Core 2 Extreme X6800,75
+Intel Core 2 Extreme X6900,75
+Intel Core 2 Extreme X7800,44
 Intel Core 2 Extreme X7900,44
+Intel Core 2 Extreme X9000,44
 Intel Core 2 Extreme X9100,44
+Intel Core 2 Quad Q6400,105
 Intel Core 2 Quad Q6600 (105W),105
 Intel Core 2 Quad Q6600 (95W),95
 Intel Core 2 Quad Q6700,95
@@ -1188,18 +1671,24 @@ Intel Core 2 Quad Q8200S,65
 Intel Core 2 Quad Q8300,95
 Intel Core 2 Quad Q8400,95
 Intel Core 2 Quad Q8400S,65
+Intel Core 2 Quad Q9000,45
 Intel Core 2 Quad Q9100,45
 Intel Core 2 Quad Q9300,95
 Intel Core 2 Quad Q9400,95
 Intel Core 2 Quad Q9400S,65
 Intel Core 2 Quad Q9450,95
+Intel Core 2 Quad Q9500,95
+Intel Core 2 Quad Q9505,95
+Intel Core 2 Quad Q9505S,65
 Intel Core 2 Quad Q9550,95
 Intel Core 2 Quad Q9550S,65
 Intel Core 2 Quad Q9650,95
+Intel Core 2 Solo SU3300,5.5
+Intel Core 2 Solo SU3500,5.5
 Intel Core 2 Solo ULV SU3300,5
 Intel Core 2 Solo ULV SU3500,5
-Intel Core 2 Solo ULV U2100,5
-Intel Core 2 Solo ULV U2200,5
+Intel Core 2 Solo ULV U2100,5.5
+Intel Core 2 Solo ULV U2200,5.5
 Intel Core Duo LV L2300,15
 Intel Core Duo LV L2400,15
 Intel Core Duo LV L2500,15
@@ -1228,89 +1717,159 @@ Intel Core Solo ULV U1400,5
 Intel Core Solo ULV U1500,5
 Intel Core i3-1000G1,12
 Intel Core i3-1000G4,12
+Intel Core i3-1000NG4,9
 Intel Core i3-1005G1,25
 Intel Core i3-10100,65
+Intel Core i3-10100E,65
+Intel Core i3-10100F,65
+Intel Core i3-10100T,35
+Intel Core i3-10100TE,35
+Intel Core i3-10100Y,5
 Intel Core i3-10105,65
 Intel Core i3-10105F,65
 Intel Core i3-10105T,35
 Intel Core i3-10110U,25
 Intel Core i3-10110Y,9
 Intel Core i3-10300,62
+Intel Core i3-10300T,35
 Intel Core i3-10305,65
 Intel Core i3-10305T,35
 Intel Core i3-10320,91
 Intel Core i3-10325,65
 Intel Core i3-10350K,91
+Intel Core i3-11100HE ,45
 Intel Core i3-1110G4,15
 Intel Core i3-1115G4,28
+Intel Core i3-1115G4E,15
+Intel Core i3-1115GRE,15
 Intel Core i3-1120G4,15
 Intel Core i3-1125G4,28
 Intel Core i3-2100,65
 Intel Core i3-2100T,35
 Intel Core i3-2102,65
 Intel Core i3-2105,65
+Intel Core i3-2115C,25
 Intel Core i3-2120,65
 Intel Core i3-2120T,35
 Intel Core i3-2125,65
 Intel Core i3-2130,65
-Intel Core i3-2312M,35
+Intel Core i3-2308M,35
+Intel Core i3-2310E,35
+Intel Core i3-2310M,35
 Intel Core i3-2312M,35
 Intel Core i3-2328M,35
 Intel Core i3-2330E,35
 Intel Core i3-2330M,35
-Intel Core i3-2330M,35
 Intel Core i3-2332M,35
 Intel Core i3-2340UE,17
+Intel Core i3-2348M,35
 Intel Core i3-2350M,35
 Intel Core i3-2357M,17
+Intel Core i3-2365M,17
 Intel Core i3-2367M,17
+Intel Core i3-2370M,35
+Intel Core i3-2375M,17
 Intel Core i3-2377M,17
 Intel Core i3-3110M,35
-Intel Core i3-3110M,35
-Intel Core i3-3120M,35
+Intel Core i3-3115C,25
 Intel Core i3-3120M,35
 Intel Core i3-3120ME,35
+Intel Core i3-3130M,35
+Intel Core i3-3210,55
 Intel Core i3-3217U,17
 Intel Core i3-3217UE,17
 Intel Core i3-3220,55
 Intel Core i3-3220T,35
 Intel Core i3-3225,55
+Intel Core i3-3227U,17
+Intel Core i3-3229Y,13
 Intel Core i3-3240,55
 Intel Core i3-3240T,35
+Intel Core i3-3245,55
+Intel Core i3-3250,55
+Intel Core i3-3250T,35
+Intel Core i3-330E,35
+Intel Core i3-330M,35
+Intel Core i3-330UM,18
 Intel Core i3-350M,35
 Intel Core i3-370M,35
 Intel Core i3-380M,35
+Intel Core i3-380UM,18
+Intel Core i3-390M,35
 Intel Core i3-4000M,37
 Intel Core i3-4005U,15
+Intel Core i3-4010M,37
+Intel Core i3-4010U,15
+Intel Core i3-4010Y,11.5
+Intel Core i3-4012Y,11.5
+Intel Core i3-4020Y,11.5
+Intel Core i3-4025U,15
+Intel Core i3-4030U,15
+Intel Core i3-4030Y,11.5
 Intel Core i3-4100E,37
+Intel Core i3-4100M,37
+Intel Core i3-4100U,15
 Intel Core i3-4102E,25
+Intel Core i3-4110E,37
+Intel Core i3-4110M,37
+Intel Core i3-4112E,25
+Intel Core i3-4120U,15
 Intel Core i3-4130,54
 Intel Core i3-4130T,35
+Intel Core i3-4150,54
 Intel Core i3-4150T,35
+Intel Core i3-4158U,28
 Intel Core i3-4160,54
 Intel Core i3-4160T,35
+Intel Core i3-4170,54
+Intel Core i3-4170T,35
 Intel Core i3-4330,54
 Intel Core i3-4330T,35
+Intel Core i3-4330TE,35
 Intel Core i3-4340,54
+Intel Core i3-4340TE,35
 Intel Core i3-4350,54
+Intel Core i3-4350T,35
 Intel Core i3-4360,54
 Intel Core i3-4360T,35
 Intel Core i3-4370,54
-Intel Core i3-4370,54
+Intel Core i3-4370T,35
 Intel Core i3-5005U,15
 Intel Core i3-5010U,15
+Intel Core i3-5015U,15
+Intel Core i3-5020U,15
 Intel Core i3-5157U,28
 Intel Core i3-530,73
 Intel Core i3-540,73
 Intel Core i3-550,73
 Intel Core i3-560,73
+Intel Core i3-6006U,15
+Intel Core i3-6098P,54
 Intel Core i3-6100,51
+Intel Core i3-6100E,35
+Intel Core i3-6100H,35
+Intel Core i3-6100T,35
+Intel Core i3-6100TE,35
+Intel Core i3-6100U,15
+Intel Core i3-6102E,25
+Intel Core i3-6157U,28
+Intel Core i3-6167U,28
 Intel Core i3-6300,51
+Intel Core i3-6300T,35
 Intel Core i3-6320,51
+Intel Core i3-7020U,15
 Intel Core i3-7100,51
+Intel Core i3-7100E,35
+Intel Core i3-7100H,35.0
 Intel Core i3-7100T,35
+Intel Core i3-7100U,15.0
+Intel Core i3-7101E,54
+Intel Core i3-7101TE,35
+Intel Core i3-7102E,25
 Intel Core i3-7120,51
 Intel Core i3-7120T,35
+Intel Core i3-7130U,15.0
+Intel Core i3-7167U,28.0
 Intel Core i3-7300,51
 Intel Core i3-7300T,35
 Intel Core i3-7320,51
@@ -1321,19 +1880,29 @@ Intel Core i3-7360X,112
 Intel Core i3-8000,65
 Intel Core i3-8020,65
 Intel Core i3-8100,62
+Intel Core i3-8100B,65
+Intel Core i3-8100F,65
+Intel Core i3-8100H,45
 Intel Core i3-8100T,35
 Intel Core i3-8109U,28
 Intel Core i3-8120,65
 Intel Core i3-8121U,28
 Intel Core i3-8130U,15
+Intel Core i3-8140U,15
 Intel Core i3-8145U,28
+Intel Core i3-8145UE,15
 Intel Core i3-8300,62
 Intel Core i3-8300T,35
 Intel Core i3-8350K,91
 Intel Core i3-9000,65
 Intel Core i3-9100,65
+Intel Core i3-9100E,65
 Intel Core i3-9100F,65
+Intel Core i3-9100HL,25
+Intel Core i3-9100T,35
+Intel Core i3-9100TE,35
 Intel Core i3-9300,62
+Intel Core i3-9300T,35
 Intel Core i3-9320,62
 Intel Core i3-9350K,91
 Intel Core i3-9350KF,91
@@ -1343,124 +1912,261 @@ Intel Core i5-10210Y,9
 Intel Core i5-10300H,45
 Intel Core i5-1030G4,12
 Intel Core i5-1030G7,12
+Intel Core i5-1030NG7,10
+Intel Core i5-10310U,15
 Intel Core i5-10310Y,9
 Intel Core i5-1035G1,25
 Intel Core i5-1035G4,25
 Intel Core i5-1035G7,25
+Intel Core i5-1038NG7,28
 Intel Core i5-10400,65
 Intel Core i5-10400F,65
 Intel Core i5-10400H,45
+Intel Core i5-10400T,35
 Intel Core i5-10500,65
+Intel Core i5-10500E,65
+Intel Core i5-10500H,45
+Intel Core i5-10500T,35
+Intel Core i5-10500TE,35
 Intel Core i5-10600,65
 Intel Core i5-10600K,125
 Intel Core i5-10600KF,95
+Intel Core i5-10600T,35
+Intel Core i5-11260H,45
+Intel Core i5-11300H,35
 Intel Core i5-1130G7,15
+Intel Core i5-11320H,35
 Intel Core i5-1135G7,28
 Intel Core i5-11400,65
 Intel Core i5-11400F,65
+Intel Core i5-11400H,45
 Intel Core i5-11400T,35
+Intel Core i5-1140G7,15
 Intel Core i5-1145G7,28
+Intel Core i5-1145G7E,15
+Intel Core i5-1145GRE,15
 Intel Core i5-11500,65
+Intel Core i5-11500H,45
+Intel Core i5-11500HE,45
 Intel Core i5-11500T,35
+Intel Core i5-1155G7,28
 Intel Core i5-11600,65
 Intel Core i5-11600K,125
 Intel Core i5-11600KF,125
 Intel Core i5-11600T,35
+Intel Core i5-2300,95
 Intel Core i5-2310,95
 Intel Core i5-2320,95
+Intel Core i5-2380P,95
 Intel Core i5-2390T,35
 Intel Core i5-2400,95
+Intel Core i5-2400S,65
 Intel Core i5-2405S,65
+Intel Core i5-2410M,35
 Intel Core i5-2415M,35
 Intel Core i5-2430M,35
-Intel Core i5-2430M,35
 Intel Core i5-2435M,35
-Intel Core i5-2435M,35
+Intel Core i5-2450M,35
+Intel Core i5-2450P,95
 Intel Core i5-2467M,17
+Intel Core i5-2500,95
+Intel Core i5-2500K,95
+Intel Core i5-2500S,65
+Intel Core i5-2500T,45
+Intel Core i5-2510E,35
+Intel Core i5-2515E,35
+Intel Core i5-2520M,35
+Intel Core i5-2537M,17
+Intel Core i5-2540M,35
+Intel Core i5-2550K,95
 Intel Core i5-2557M,17
 Intel Core i5-3210M,35
-Intel Core i5-3210M,35
+Intel Core i5-3230M,35
 Intel Core i5-3317U,17
-Intel Core i5-3320M,35
 Intel Core i5-3320M,35
 Intel Core i5-3330,77
 Intel Core i5-3330S,77
 Intel Core i5-3335S,65
+Intel Core i5-3337U,17
+Intel Core i5-3339Y,13
+Intel Core i5-3340,77
+Intel Core i5-3340M,35
+Intel Core i5-3340S,65
 Intel Core i5-3350P,69
 Intel Core i5-3360M,35
-Intel Core i5-3360M,35
 Intel Core i5-3365M,35
+Intel Core i5-3380M,35
 Intel Core i5-3427U,17
+Intel Core i5-3437U,17
+Intel Core i5-3439Y,13
+Intel Core i5-3450,77
+Intel Core i5-3450S,65
 Intel Core i5-3470,77
 Intel Core i5-3470S,65
 Intel Core i5-3470T,35
 Intel Core i5-3475S,65
+Intel Core i5-3550,77
+Intel Core i5-3550S,65
 Intel Core i5-3570,77
+Intel Core i5-3570K,77
 Intel Core i5-3570S,65
+Intel Core i5-3570T,45
 Intel Core i5-3610ME,35
-Intel Core i5-3610ME,35
+Intel Core i5-4200H,47
+Intel Core i5-4200M,37
 Intel Core i5-4200U,15
-Intel Core i5-4200Y,12
+Intel Core i5-4200Y,11.5
+Intel Core i5-4202Y,11.5
+Intel Core i5-4210H,47
+Intel Core i5-4210M,37
 Intel Core i5-4210U,15
+Intel Core i5-4210Y,11.5
+Intel Core i5-4220Y,11.5
 Intel Core i5-4250U,15
+Intel Core i5-4258U,28
+Intel Core i5-4260U,15
+Intel Core i5-4278U,28
+Intel Core i5-4288U,28
 Intel Core i5-4300M,37
+Intel Core i5-4300U,15
+Intel Core i5-4300Y,11.5
+Intel Core i5-4302Y,11.5
+Intel Core i5-4308U,28
 Intel Core i5-430M,35
+Intel Core i5-430UM,18
+Intel Core i5-4310M,37
+Intel Core i5-4310U,15
 Intel Core i5-4330M,37
+Intel Core i5-4340M,37
 Intel Core i5-4350U,15
+Intel Core i5-4360U,15
+Intel Core i5-4400E,37
+Intel Core i5-4402E,25
+Intel Core i5-4402EC,27
+Intel Core i5-4410E,37
+Intel Core i5-4422E,25
+Intel Core i5-4430,84
+Intel Core i5-4430S,65
 Intel Core i5-4440,84
 Intel Core i5-4440S,65
+Intel Core i5-4460,84
+Intel Core i5-4460S,65
+Intel Core i5-4460T,35
 Intel Core i5-450M,35
+Intel Core i5-4570,84
+Intel Core i5-4570R,65
+Intel Core i5-4570S,65
+Intel Core i5-4570T,35
+Intel Core i5-4570TE,35
 Intel Core i5-4590,84
 Intel Core i5-4590S,65
+Intel Core i5-4590T,35
 Intel Core i5-460M,35
+Intel Core i5-4670,84
+Intel Core i5-4670K,84
+Intel Core i5-4670R,65
+Intel Core i5-4670S,65
+Intel Core i5-4670T,45
 Intel Core i5-4690,84
 Intel Core i5-4690K,88
+Intel Core i5-4690S,65
+Intel Core i5-4690T,45
+Intel Core i5-470UM,18
+Intel Core i5-480M,35
 Intel Core i5-5200U,15
+Intel Core i5-520E,35
+Intel Core i5-520M,35
+Intel Core i5-520UM,18
 Intel Core i5-5250U,15
 Intel Core i5-5257U,28
 Intel Core i5-5287U,28
 Intel Core i5-5300U,15
+Intel Core i5-5350H,47
 Intel Core i5-5350U,15
 Intel Core i5-540M,35
+Intel Core i5-540UM,18
+Intel Core i5-5575R,65
 Intel Core i5-560M,35
+Intel Core i5-560UM,18
 Intel Core i5-5675C,65
+Intel Core i5-5675R,65
 Intel Core i5-580M,35
+Intel Core i5-6198DU,15
+Intel Core i5-6200U,15
+Intel Core i5-6260U,15
+Intel Core i5-6267U,28
+Intel Core i5-6287U,28
+Intel Core i5-6300HQ,45
+Intel Core i5-6300U,15
 Intel Core i5-6350HQ,45
+Intel Core i5-6360U,15
 Intel Core i5-6400,65
+Intel Core i5-6400T,35
+Intel Core i5-6402P,65
+Intel Core i5-6440EQ,45
+Intel Core i5-6440HQ,45
+Intel Core i5-6442EQ,25
 Intel Core i5-650,73
 Intel Core i5-6500,65
+Intel Core i5-6500T,35
+Intel Core i5-6500TE,35
 Intel Core i5-655K,73
+Intel Core i5-6585R,65
 Intel Core i5-660,73
 Intel Core i5-6600,65
 Intel Core i5-6600K,95
+Intel Core i5-6600T,35
 Intel Core i5-661,87
+Intel Core i5-6685R,65
 Intel Core i5-670,73
 Intel Core i5-680,73
+Intel Core i5-7200U,15.0
+Intel Core i5-7260U,15.0
+Intel Core i5-7267U,28.0
+Intel Core i5-7287U,28.0
 Intel Core i5-7300HQ,45
+Intel Core i5-7300U,15.0
+Intel Core i5-7360U,15.0
 Intel Core i5-7400,65
 Intel Core i5-7400T,35
+Intel Core i5-7440EQ,45
+Intel Core i5-7440HQ,45.0
+Intel Core i5-7442EQ,25
 Intel Core i5-750,95
 Intel Core i5-7500,65
 Intel Core i5-7500T,35
+Intel Core i5-750S,82
 Intel Core i5-750s,82
 Intel Core i5-760,95
 Intel Core i5-7600,65
 Intel Core i5-7600K,91
 Intel Core i5-7600T,35
 Intel Core i5-7640X,112
+Intel Core i5-7Y54,4.5
+Intel Core i5-7Y57,4.5
+Intel Core i5-8200Y,5
+Intel Core i5-8210Y,7
 Intel Core i5-8250U,15
+Intel Core i5-8257U,15
 Intel Core i5-8259U,28
+Intel Core i5-8260U,15
 Intel Core i5-8265U,28
 Intel Core i5-8269U,28
+Intel Core i5-8279U,28
 Intel Core i5-8300H,45
 Intel Core i5-8305G,65
+Intel Core i5-8310Y,7
 Intel Core i5-8350U,15
+Intel Core i5-8365U,15
+Intel Core i5-8365UE,15
 Intel Core i5-8400,65
+Intel Core i5-8400B,65
 Intel Core i5-8400H,45
 Intel Core i5-8400T,35
 Intel Core i5-8420,65
 Intel Core i5-8420T,35
 Intel Core i5-8500,65
+Intel Core i5-8500B,65
 Intel Core i5-8500T,35
 Intel Core i5-8550,65
 Intel Core i5-8600,65
@@ -1468,24 +2174,35 @@ Intel Core i5-8600K,95
 Intel Core i5-8600T,35
 Intel Core i5-8650,65
 Intel Core i5-8650K,95
+Intel Core i5-9300H,45
+Intel Core i5-9300HF,45
 Intel Core i5-9400,65
 Intel Core i5-9400F,65
+Intel Core i5-9400H,45
 Intel Core i5-9400T,35
 Intel Core i5-9500,65
+Intel Core i5-9500E,65
 Intel Core i5-9500F,65
+Intel Core i5-9500T,35
+Intel Core i5-9500TE,35
 Intel Core i5-9600,65
 Intel Core i5-9600K,95
 Intel Core i5-9600KF,95
+Intel Core i5-9600T,35
 Intel Core i7-10510U,25
 Intel Core i7-10510Y,9
 Intel Core i7-1060G7,12
 Intel Core i7-10610U,25
 Intel Core i7-1065G7,25
 Intel Core i7-1068G7,28
+Intel Core i7-1068NG7,28
 Intel Core i7-10700,65
+Intel Core i7-10700E,65
 Intel Core i7-10700F,65
 Intel Core i7-10700K,125
 Intel Core i7-10700KF,125
+Intel Core i7-10700T,35
+Intel Core i7-10700TE,35
 Intel Core i7-10710U,25
 Intel Core i7-10750H,45
 Intel Core i7-10810U,25
@@ -1494,66 +2211,137 @@ Intel Core i7-10870H,45
 Intel Core i7-10875H,45
 Intel Core i7-10885H,45
 Intel Core i7-11370H,28
+Intel Core i7-11375H,35
+Intel Core i7-11390H,35
+Intel Core i7-11600H,45
 Intel Core i7-1160G7,15
 Intel Core i7-1165G7,28
 Intel Core i7-11700,65
+Intel Core i7-11700B,65
 Intel Core i7-11700F,65
 Intel Core i7-11700K,125
 Intel Core i7-11700KF,125
 Intel Core i7-11700T,35
+Intel Core i7-11800H,45
+Intel Core i7-1180G7,15
+Intel Core i7-11850H,45
+Intel Core i7-11850HE,45
 Intel Core i7-1185G7,28
+Intel Core i7-1185G7E,28
+Intel Core i7-1185GRE,28
+Intel Core i7-1195G7,28
 Intel Core i7-1270P,64
+Intel Core i7-2600,95
+Intel Core i7-2600K,95
+Intel Core i7-2600S,65
+Intel Core i7-2610UE,17
+Intel Core i7-2617M,17
+Intel Core i7-2620M,35
+Intel Core i7-2629M,25
+Intel Core i7-2630QM,45
+Intel Core i7-2635QM,45
+Intel Core i7-2637M,17
+Intel Core i7-2640M,35
+Intel Core i7-2649M,25
+Intel Core i7-2655LE,25
+Intel Core i7-2657M,17
 Intel Core i7-2670QM,45
 Intel Core i7-2675QM,45
+Intel Core i7-2677M,17
 Intel Core i7-2700K,95
+Intel Core i7-2710QE,45
+Intel Core i7-2715QE,45
 Intel Core i7-2760QM,45
-Intel Core i7-2760QM,45
+Intel Core i7-2820QM,45
 Intel Core i7-2860QM,45
-Intel Core i7-2860QM,45
+Intel Core i7-2920XM,55
 Intel Core i7-2960XM,55
 Intel Core i7-3517U,17
 Intel Core i7-3517UE,17
 Intel Core i7-3520M,35
-Intel Core i7-3520M,35
 Intel Core i7-3525M,35
+Intel Core i7-3537U,17
+Intel Core i7-3540M,35
 Intel Core i7-3555LE,25
+Intel Core i7-3610QE,45
+Intel Core i7-3610QM,45
+Intel Core i7-3612QE,35
+Intel Core i7-3612QM,35
+Intel Core i7-3615QE,45
+Intel Core i7-3615QM,45
 Intel Core i7-3630QM,45
-Intel Core i7-3632QM,35
 Intel Core i7-3632QM,35
 Intel Core i7-3635QM,45
 Intel Core i7-3667U,17
+Intel Core i7-3687U,17
+Intel Core i7-3689Y,13
+Intel Core i7-3720QM,45
 Intel Core i7-3740QM,45
-Intel Core i7-3740QM,45
-Intel Core i7-3840QM,45
+Intel Core i7-3770,77
+Intel Core i7-3770K,77
+Intel Core i7-3770S,65
+Intel Core i7-3770T,45
+Intel Core i7-3820,130
+Intel Core i7-3820QM,45
 Intel Core i7-3840QM,45
 Intel Core i7-3910K,130
+Intel Core i7-3920XM,55
 Intel Core i7-3930K,130
 Intel Core i7-3940XM,55
 Intel Core i7-3960X,130
 Intel Core i7-3970X,150
 Intel Core i7-4500U,15
+Intel Core i7-4510U,15
 Intel Core i7-4550U,15
 Intel Core i7-4558U,28
+Intel Core i7-4578U,28
 Intel Core i7-4600M,37
 Intel Core i7-4600U,15
 Intel Core i7-4610M,37
+Intel Core i7-4610Y,11.5
 Intel Core i7-4650U,15
+Intel Core i7-4700EC,43
+Intel Core i7-4700EQ,47
+Intel Core i7-4700HQ,47
+Intel Core i7-4700MQ,47
+Intel Core i7-4701EQ,47
+Intel Core i7-4702EC,27
+Intel Core i7-4702HQ,37
+Intel Core i7-4702MQ,37
 Intel Core i7-4710HQ,47
+Intel Core i7-4710MQ,47
 Intel Core i7-4712HQ,37
+Intel Core i7-4712MQ,37
+Intel Core i7-4720HQ,47
+Intel Core i7-4722HQ,37
+Intel Core i7-4750HQ,47
 Intel Core i7-4760HQ,47
+Intel Core i7-4765T,35
+Intel Core i7-4770,84
 Intel Core i7-4770HQ,47
+Intel Core i7-4770K,84
+Intel Core i7-4770R,65
+Intel Core i7-4770S,65
+Intel Core i7-4770T,45
+Intel Core i7-4770TE,45
 Intel Core i7-4771,84
+Intel Core i7-4785T,35
 Intel Core i7-4790,84
 Intel Core i7-4790K,88
 Intel Core i7-4790S,65
+Intel Core i7-4790T,45
+Intel Core i7-4800MQ,47
 Intel Core i7-4810MQ,47
 Intel Core i7-4820K,130
 Intel Core i7-4850EQ,47
+Intel Core i7-4850HQ,47
 Intel Core i7-4860EQ,47
 Intel Core i7-4860HQ,47
 Intel Core i7-4870HQ,47
+Intel Core i7-4900MQ,47
 Intel Core i7-4910MQ,47
 Intel Core i7-4930K,130
+Intel Core i7-4930MX,57
 Intel Core i7-4940MX,57
 Intel Core i7-4950HQ,47
 Intel Core i7-4960HQ,47
@@ -1564,40 +2352,93 @@ Intel Core i7-5550U,15
 Intel Core i7-5557U,28
 Intel Core i7-5600U,15
 Intel Core i7-5650U,15
+Intel Core i7-5700EQ,47
+Intel Core i7-5700HQ,47
+Intel Core i7-5750HQ,47
 Intel Core i7-5775C,65
+Intel Core i7-5775R,65
 Intel Core i7-5820K,140
+Intel Core i7-5850EQ,47
+Intel Core i7-5850HQ,47
 Intel Core i7-5930K,140
+Intel Core i7-5950HQ,47
 Intel Core i7-5960X,140
+Intel Core i7-610E,35
+Intel Core i7-620LE,25
+Intel Core i7-620LM,25
 Intel Core i7-620M,35
-Intel Core i7-620M,35
+Intel Core i7-620UE,18
+Intel Core i7-620UM,18
+Intel Core i7-640LM,25
 Intel Core i7-640M,35
-Intel Core i7-640M,35
+Intel Core i7-640UM,18
+Intel Core i7-6498DU,15
+Intel Core i7-6500U,15
+Intel Core i7-6560U,15
+Intel Core i7-6567U,28
+Intel Core i7-6600U,15
+Intel Core i7-660LM,25
+Intel Core i7-660UE,18
+Intel Core i7-660UM,18
+Intel Core i7-6650U,15
+Intel Core i7-6660U,15
 Intel Core i7-6700,65
+Intel Core i7-6700HQ,45
 Intel Core i7-6700K,95
 Intel Core i7-6700T,35
 Intel Core i7-6700TE,35
+Intel Core i7-6770HQ,45
+Intel Core i7-6785R,65
 Intel Core i7-6800K,140
+Intel Core i7-680UM,18
+Intel Core i7-6820EQ,45
+Intel Core i7-6820HK,45
+Intel Core i7-6820HQ,45
+Intel Core i7-6822EQ,25
 Intel Core i7-6850K,140
+Intel Core i7-6870HQ,45
 Intel Core i7-6900K,140
+Intel Core i7-6920HQ,45
 Intel Core i7-6950X,140
+Intel Core i7-6970HQ,45
+Intel Core i7-720QM,45
+Intel Core i7-740QM,45
+Intel Core i7-7500U,15.0
+Intel Core i7-7560U,15.0
+Intel Core i7-7567U,28.0
 Intel Core i7-7600U,15
+Intel Core i7-7660U,15.0
 Intel Core i7-7700,65
+Intel Core i7-7700HQ,45.0
 Intel Core i7-7700K,91
 Intel Core i7-7700T,35
 Intel Core i7-7740X,112
 Intel Core i7-7800X,140
+Intel Core i7-7820EQ,45
+Intel Core i7-7820HK,45.0
+Intel Core i7-7820HQ,45.0
 Intel Core i7-7820X,140
+Intel Core i7-7920HQ,45.0
+Intel Core i7-7Y75,4.5
 Intel Core i7-8086K,95
+Intel Core i7-820QM,45
+Intel Core i7-840QM,45
+Intel Core i7-8500Y,5
 Intel Core i7-8550U,15
+Intel Core i7-8557U,15
 Intel Core i7-8559U,28
 Intel Core i7-8565U,28
+Intel Core i7-8569U,28
 Intel Core i7-860,95
 Intel Core i7-860S,82
 Intel Core i7-8650U,15
+Intel Core i7-8665U,15
+Intel Core i7-8665UE,15
 Intel Core i7-8670,65
 Intel Core i7-8670T,35
 Intel Core i7-870,95
 Intel Core i7-8700,65
+Intel Core i7-8700B,65
 Intel Core i7-8700K,95
 Intel Core i7-8700T,35
 Intel Core i7-8705G,65
@@ -1610,17 +2451,24 @@ Intel Core i7-880,95
 Intel Core i7-8809G,65
 Intel Core i7-8850H,45
 Intel Core i7-920,130
+Intel Core i7-920XM,55
 Intel Core i7-930,130
 Intel Core i7-940,130
+Intel Core i7-940XM,55
 Intel Core i7-950,130
 Intel Core i7-960,130
 Intel Core i7-965,130
+Intel Core i7-965 Extreme Edition,130
 Intel Core i7-970,130
 Intel Core i7-9700,65
+Intel Core i7-9700E,65
 Intel Core i7-9700F,65
 Intel Core i7-9700K,95
 Intel Core i7-9700KF,95
+Intel Core i7-9700T,35
+Intel Core i7-9700TE,35
 Intel Core i7-975,130
+Intel Core i7-975 Extreme Edition,130
 Intel Core i7-9750H,45
 Intel Core i7-9750HF,45
 Intel Core i7-980,130
@@ -1633,10 +2481,13 @@ Intel Core i7-990X,130
 Intel Core i9-10800F,65
 Intel Core i9-10850K,125
 Intel Core i9-10900,65
+Intel Core i9-10900E,65
 Intel Core i9-10900F,65
 Intel Core i9-10900K,125
 Intel Core i9-10900KF,125
+Intel Core i9-10900T,35
 Intel Core i9-10900X,165
+Intel Core i9-10910,125
 Intel Core i9-10920X,165
 Intel Core i9-10940X,165
 Intel Core i9-10980HK,45
@@ -1659,6 +2510,7 @@ Intel Core i9-9900,65
 Intel Core i9-9900K,95
 Intel Core i9-9900KF,95
 Intel Core i9-9900KS,127
+Intel Core i9-9900T,35
 Intel Core i9-9900X,165
 Intel Core i9-9920X,165
 Intel Core i9-9940X,165
@@ -1666,7 +2518,18 @@ Intel Core i9-9960X,165
 Intel Core i9-9980HK,45
 Intel Core i9-9980XE,165
 Intel Core i9-9990XE,255
+Intel Core m3-8100Y,5
 Intel Core m3-8114Y,28
+Intel Core i7-2720QM,45
+Intel Core i7-2760QM,45
+Intel Mobile Celeron 266,9.8
+Intel Mobile Celeron 300,11.1
+Intel Mobile Celeron 333,11.8
+Intel Mobile Celeron 366,13.1
+Intel Mobile Celeron 400,13.8
+Intel Mobile Celeron 433,19.4
+Intel Mobile Celeron 466,20.7
+Intel Mobile Celeron LV 266,7.9
 Intel Mobile Pentium 4 2.40,60
 Intel Mobile Pentium 4 2.66,66
 Intel Mobile Pentium 4 2.80,68
@@ -1680,35 +2543,42 @@ Intel Mobile Pentium 4 HT 532,88
 Intel Mobile Pentium 4 HT 538,88
 Intel Mobile Pentium 4 HT 548,88
 Intel Mobile Pentium 4 HT 552,88
+Intel Pentium 100,10.1
+Intel Pentium 120,12.81
+Intel Pentium 133,11.2
+Intel Pentium 1403,80
+Intel Pentium 1403 v2,80
+Intel Pentium 1405,40
+Intel Pentium 1405 v2,40
+Intel Pentium 1407,80
+Intel Pentium 150,11.6
+Intel Pentium 166,14.5
+Intel Pentium 200,15.5
 Intel Pentium 2020M,35
+Intel Pentium 2030M,35
 Intel Pentium 2117U,17
-Intel Pentium 2117U,17
+Intel Pentium 2127U,17
 Intel Pentium 2129Y,10
 Intel Pentium 350,15
 Intel Pentium 3550M,37
 Intel Pentium 3556U,15
-Intel Pentium 3560Y,12
+Intel Pentium 3558U,15
+Intel Pentium 3560M,37
+Intel Pentium 3560Y,11.5
+Intel Pentium 3561Y,11.5
 Intel Pentium 3805U,15
+Intel Pentium 3825U,15
 Intel Pentium 4 1.3,52
 Intel Pentium 4 1.4,55
-Intel Pentium 4 1.4,55
-Intel Pentium 4 1.5,58
 Intel Pentium 4 1.5,58
 Intel Pentium 4 1.6,61
-Intel Pentium 4 1.6,61
-Intel Pentium 4 1.7,64
 Intel Pentium 4 1.7,64
 Intel Pentium 4 1.80,67
 Intel Pentium 4 1.8A,67
 Intel Pentium 4 1.9,69
-Intel Pentium 4 1.9,69
-Intel Pentium 4 2.0,72
-Intel Pentium 4 2.0,110
-Intel Pentium 4 2.0,72
 Intel Pentium 4 2.0,92
 Intel Pentium 4 2.2,92
 Intel Pentium 4 2.26,110
-Intel Pentium 4 2.4,92
 Intel Pentium 4 2.4,110
 Intel Pentium 4 2.40,110
 Intel Pentium 4 2.53,110
@@ -1718,13 +2588,8 @@ Intel Pentium 4 2.80,110
 Intel Pentium 4 505,84
 Intel Pentium 4 505J,84
 Intel Pentium 4 506,84
-Intel Pentium 4 506,84
-Intel Pentium 4 506,84
-Intel Pentium 4 511,84
-Intel Pentium 4 511,84
 Intel Pentium 4 511,84
 Intel Pentium 4 519,84
-Intel Pentium 4 519K,84
 Intel Pentium 4 519K,84
 Intel Pentium 4 HT 2.40,66
 Intel Pentium 4 HT 2.60,69
@@ -1739,17 +2604,10 @@ Intel Pentium 4 HT 3.40,89
 Intel Pentium 4 HT 3.4E,115
 Intel Pentium 4 HT 3.6E,115
 Intel Pentium 4 HT 515,84
-Intel Pentium 4 HT 515,84
-Intel Pentium 4 HT 516,84
 Intel Pentium 4 HT 516,84
 Intel Pentium 4 HT 517,84
-Intel Pentium 4 HT 517,84
-Intel Pentium 4 HT 520,84
-Intel Pentium 4 HT 520,84
-Intel Pentium 4 HT 520,84
 Intel Pentium 4 HT 520,84
 Intel Pentium 4 HT 521,84
-Intel Pentium 4 HT 524,84
 Intel Pentium 4 HT 524,84
 Intel Pentium 4 HT 530,84
 Intel Pentium 4 HT 531,84
@@ -1775,7 +2633,6 @@ Intel Pentium 4 HT 670,84
 Intel Pentium 4 HT 672,84
 Intel Pentium 4 HT EE 3.20,110
 Intel Pentium 4 HT EE 3.40,110
-Intel Pentium 4 HT EE 3.40,110
 Intel Pentium 4 HT EE 3.46,110
 Intel Pentium 4 HT EE 3.73,115
 Intel Pentium 4-M 1.40,21
@@ -1789,14 +2646,26 @@ Intel Pentium 4-M 2.20,35
 Intel Pentium 4-M 2.40,35
 Intel Pentium 4-M 2.50,35
 Intel Pentium 4-M 2.60,35
+Intel Pentium 4405U,15
+Intel Pentium 4405Y,6
+Intel Pentium 60,14.6
+Intel Pentium 66,16
+Intel Pentium 6805,15
+Intel Pentium 75,8
+Intel Pentium 90,9
 Intel Pentium 957,17
 Intel Pentium 967,17
+Intel Pentium 977,17
+Intel Pentium 987,17
 Intel Pentium 997,17
+Intel Pentium A1018,35
+Intel Pentium B915C,15
+Intel Pentium B925C,15
 Intel Pentium B940,35
 Intel Pentium B950,35
 Intel Pentium B960,35
+Intel Pentium B970,35
 Intel Pentium B980,35
-Intel Pentium D 820,130
 Intel Pentium D 820,130
 Intel Pentium D 830,130
 Intel Pentium D 840,130
@@ -1812,12 +2681,30 @@ Intel Pentium D 950,130
 Intel Pentium D 955 EE,130
 Intel Pentium D 960,130
 Intel Pentium D 965 EE,130
+Intel Pentium D1507,20
+Intel Pentium D1508,25
+Intel Pentium D1509,19
+Intel Pentium D1517,25
+Intel Pentium D1519,25
 Intel Pentium Dual-Core E2140,65
 Intel Pentium Dual-Core E2160,65
 Intel Pentium Dual-Core E2180,65
 Intel Pentium Dual-Core E2200,65
 Intel Pentium Dual-Core E2210,65
 Intel Pentium Dual-Core E2220,65
+Intel Pentium Dual-Core E5200,65
+Intel Pentium Dual-Core E5300,65
+Intel Pentium Dual-Core T2060,31
+Intel Pentium Dual-Core T2080,31
+Intel Pentium Dual-Core T2130,31
+Intel Pentium Dual-Core T2310,35
+Intel Pentium Dual-Core T2330,35
+Intel Pentium Dual-Core T2350,31
+Intel Pentium Dual-Core T2370,35
+Intel Pentium Dual-Core T2390,35
+Intel Pentium Dual-Core T2410,35
+Intel Pentium Dual-Core T3200,35
+Intel Pentium Dual-Core T3400,35
 Intel Pentium Dual-Core T4200,35
 Intel Pentium Dual-Core T4300,35
 Intel Pentium Dual-Core T4400,35
@@ -1834,22 +2721,41 @@ Intel Pentium E6500K,65
 Intel Pentium E6600,65
 Intel Pentium E6700,65
 Intel Pentium E6800,65
+Intel Pentium G2010,55
+Intel Pentium G2020,55
+Intel Pentium G2020T,35
+Intel Pentium G2030,55
+Intel Pentium G2030T,35
 Intel Pentium G2100T,35
 Intel Pentium G2120,55
+Intel Pentium G2120T,35
+Intel Pentium G2130,55
+Intel Pentium G2140,55
 Intel Pentium G3220,54
 Intel Pentium G3220T,35
+Intel Pentium G3240,53
+Intel Pentium G3240T,35
 Intel Pentium G3250,54
 Intel Pentium G3250T,35
 Intel Pentium G3258,54
+Intel Pentium G3260,53
+Intel Pentium G3260T,35
+Intel Pentium G3320TE,35
 Intel Pentium G3420,54
 Intel Pentium G3420T,35
 Intel Pentium G3430,54
 Intel Pentium G3440,54
+Intel Pentium G3440T,35
 Intel Pentium G3450,54
 Intel Pentium G3450T,35
 Intel Pentium G3460,54
+Intel Pentium G3460T,35
+Intel Pentium G3470,53
 Intel Pentium G4400,51
+Intel Pentium G4400T,35
+Intel Pentium G4400TE,35
 Intel Pentium G4500,51
+Intel Pentium G4500T,35
 Intel Pentium G4520,51
 Intel Pentium G4560,51
 Intel Pentium G4560T,35
@@ -1868,28 +2774,47 @@ Intel Pentium G645,65
 Intel Pentium G645T,35
 Intel Pentium G6950,73
 Intel Pentium G6951,73
+Intel Pentium G6960,73
 Intel Pentium G840,65
 Intel Pentium G850,65
 Intel Pentium G860,65
 Intel Pentium G860T,35
 Intel Pentium G870,65
-Intel Pentium Gold G5400,51
+Intel Pentium Gold 4410Y,6
+Intel Pentium Gold 4415U,15
+Intel Pentium Gold 4415Y,6
+Intel Pentium Gold 4417U,15
+Intel Pentium Gold 4425Y,6
+Intel Pentium Gold 5405U,15
+Intel Pentium Gold 6405U,15
+Intel Pentium Gold 6500Y,5
+Intel Pentium Gold 7505,15
+Intel Pentium Gold G5400,58
+Intel Pentium Gold G5400T,35
+Intel Pentium Gold G5420,54
+Intel Pentium Gold G5420T,35
 Intel Pentium Gold G5500,51
+Intel Pentium Gold G5500T,35
 Intel Pentium Gold G5600,51
+Intel Pentium Gold G5600E,35
+Intel Pentium Gold G5600T,35
 Intel Pentium Gold G5620,51
 Intel Pentium Gold G6400,58
+Intel Pentium Gold G6400E,58
+Intel Pentium Gold G6400T,35
+Intel Pentium Gold G6400TE,35
 Intel Pentium Gold G6405,65
 Intel Pentium Gold G6405T,35
 Intel Pentium Gold G6500,58
+Intel Pentium Gold G6500T,35
 Intel Pentium Gold G6505,65
 Intel Pentium Gold G6505T,35
 Intel Pentium Gold G6600,58
 Intel Pentium Gold G6605,65
-Intel Pentium III 1000,30
+Intel Pentium II Xeon 400,38.1
+Intel Pentium II Xeon 450,46.7
 Intel Pentium III 1000,29
 Intel Pentium III 1000S,30
-Intel Pentium III 1133,29
-Intel Pentium III 1133,29
 Intel Pentium III 1133,29
 Intel Pentium III 1133S,29
 Intel Pentium III 1200,30
@@ -1900,6 +2825,22 @@ Intel Pentium III 1400S,32
 Intel Pentium III 800,38
 Intel Pentium III 866,38
 Intel Pentium III 933,27
+Intel Pentium III Xeon 1.00,30.8
+Intel Pentium III Xeon 500,36.2
+Intel Pentium III Xeon 550,34
+Intel Pentium III Xeon 600,19.2
+Intel Pentium III Xeon 667,21.3
+Intel Pentium III Xeon 700,29.6
+Intel Pentium III Xeon 733,23.3
+Intel Pentium III Xeon 800,25.4
+Intel Pentium III Xeon 866,29.6
+Intel Pentium III Xeon 900,39.3
+Intel Pentium III Xeon 933,29.6
+Intel Pentium J2850,10
+Intel Pentium J2900,10
+Intel Pentium J3710,6.5
+Intel Pentium J4205,10
+Intel Pentium J6426,10
 Intel Pentium M 1.30,24
 Intel Pentium M 1.40,24
 Intel Pentium M 1.50,24
@@ -1917,37 +2858,78 @@ Intel Pentium M 760,27
 Intel Pentium M 765,21
 Intel Pentium M 770,27
 Intel Pentium M 780,27
+Intel Pentium MMX 166,13.1
+Intel Pentium MMX 200,15.7
+Intel Pentium MMX 233,17
+Intel Pentium N3510,7.5
+Intel Pentium N3520,7.5
+Intel Pentium N3530,7.5
+Intel Pentium N3540,7.5
+Intel Pentium N3700,6
+Intel Pentium N3710,6
+Intel Pentium N4200,6
+Intel Pentium N6415,6.5
 Intel Pentium P6000,35
 Intel Pentium P6100,35
 Intel Pentium P6200,35
+Intel Pentium P6300,35
 Intel Pentium SU2700,10
 Intel Pentium SU4100,10
 Intel Pentium Silver J5005,10
+Intel Pentium Silver J5040,10
+Intel Pentium Silver N5000,6
+Intel Pentium Silver N5030,6
+Intel Pentium Silver N6000,6
+Intel Pentium Silver N6005,10
+Intel Pentium T4200,35
+Intel Pentium T4300,35
+Intel Pentium T4400,35
+Intel Pentium T4500,35
 Intel Pentium U5400,18
+Intel Pentium U5600,18
+Intel Xeon 1.4,56
+Intel Xeon 1.5,59.2
+Intel Xeon 1.7,65.8
+Intel Xeon 1.8,55
 Intel Xeon 2.0,89
+Intel Xeon 2.0A,58
+Intel Xeon 2.0B,58
+Intel Xeon 2.2,61
 Intel Xeon 2.4,89
+Intel Xeon 2.4B,77
+Intel Xeon 2.6,60
 Intel Xeon 2.66,89
-Intel Xeon 2.8,135
-Intel Xeon 2.8,135
 Intel Xeon 2.8,89
+Intel Xeon 2.8B,77
+Intel Xeon 2.8D,103
+Intel Xeon 2.8E,110
 Intel Xeon 3.0,135
-Intel Xeon 3.0,135
-Intel Xeon 3.06,97
-Intel Xeon 3.06,97
 Intel Xeon 3.06,89
-Intel Xeon 3.2,135
+Intel Xeon 3.0D,103
+Intel Xeon 3.0E,110
 Intel Xeon 3.2,135
 Intel Xeon 3.20,97
-Intel Xeon 3.20,97
+Intel Xeon 3.2E,110
 Intel Xeon 3.4,135
-Intel Xeon 3.4,135
+Intel Xeon 3.4E,110
 Intel Xeon 3.6,135
-Intel Xeon 3.6,135
+Intel Xeon 3.6E,110
+Intel Xeon 3.8,110
+Intel Xeon 3.8E,110
+Intel Xeon 3040,65
+Intel Xeon 3050,65
+Intel Xeon 3060,65
+Intel Xeon 3065,65
+Intel Xeon 3070,65
+Intel Xeon 3075,65
+Intel Xeon 3085,65
+Intel Xeon 5020,95
 Intel Xeon 5030,95
 Intel Xeon 5040,95
 Intel Xeon 5050,95
 Intel Xeon 5060,130
 Intel Xeon 5063,95
+Intel Xeon 5070,130
 Intel Xeon 5080,130
 Intel Xeon 5110,65
 Intel Xeon 5120,65
@@ -1956,6 +2938,11 @@ Intel Xeon 5140,65
 Intel Xeon 5148,40
 Intel Xeon 5150,65
 Intel Xeon 5160,80
+Intel Xeon 5320,185
+Intel Xeon 7020,165
+Intel Xeon 7030,165
+Intel Xeon 7040,165
+Intel Xeon 7041,165
 Intel Xeon 7110M,95
 Intel Xeon 7110N,95
 Intel Xeon 7120M,95
@@ -1964,73 +2951,364 @@ Intel Xeon 7130M,150
 Intel Xeon 7130N,150
 Intel Xeon 7140M,150
 Intel Xeon 7140N,150
+Intel Xeon 7150N,150
+Intel Xeon AWS-1100 v4,145
+Intel Xeon Bronze 3104,85
 Intel Xeon Bronze 3106,85
+Intel Xeon Bronze 3204,85
+Intel Xeon Bronze 3206R,85
+Intel Xeon D-1513N,35
+Intel Xeon D-1518,35
+Intel Xeon D-1520,45
+Intel Xeon D-1521,45
+Intel Xeon D-1523N,45
+Intel Xeon D-1527,35
+Intel Xeon D-1528,35
+Intel Xeon D-1529,20
+Intel Xeon D-1531,45
+Intel Xeon D-1533N,45
+Intel Xeon D-1537,35
+Intel Xeon D-1539,35
+Intel Xeon D-1540,45
+Intel Xeon D-1541,45
+Intel Xeon D-1543N,45
+Intel Xeon D-1548,45
+Intel Xeon D-1553N,65
+Intel Xeon D-1557,45
+Intel Xeon D-1559,45
+Intel Xeon D-1567,65
+Intel Xeon D-1571,45
+Intel Xeon D-1577,45
+Intel Xeon D-1581,65
+Intel Xeon D-1587,65
+Intel Xeon D-1602,27
+Intel Xeon D-1622,40
+Intel Xeon D-1623N,35
+Intel Xeon D-1627,45
+Intel Xeon D-1633N,45
+Intel Xeon D-1637,55
+Intel Xeon D-1649N,45
+Intel Xeon D-1653N,65
+Intel Xeon D-2123IT,60
+Intel Xeon D-2141I,65
+Intel Xeon D-2142IT,65
+Intel Xeon D-2143IT,65
+Intel Xeon D-2145NT,65
+Intel Xeon D-2146NT,80
+Intel Xeon D-2161I,90
+Intel Xeon D-2163IT,75
+Intel Xeon D-2166NT,85
+Intel Xeon D-2173IT,70
+Intel Xeon D-2177NT,105
+Intel Xeon D-2183IT,100
+Intel Xeon D-2187NT,110
+Intel Xeon D-2191,86
+Intel Xeon E-2104G,65
 Intel Xeon E-2124,72
 Intel Xeon E-2124G,72
+Intel Xeon E-2126G,80
+Intel Xeon E-2134,71
+Intel Xeon E-2136,80
+Intel Xeon E-2144G,71
+Intel Xeon E-2146G,80
+Intel Xeon E-2174G,71
+Intel Xeon E-2176G,80
+Intel Xeon E-2176M,45
+Intel Xeon E-2186G,95
+Intel Xeon E-2186M,45
+Intel Xeon E-2224,71
+Intel Xeon E-2224G,71
+Intel Xeon E-2226G,80
+Intel Xeon E-2226GE,80
+Intel Xeon E-2234,71
+Intel Xeon E-2236,80
+Intel Xeon E-2244G,71
+Intel Xeon E-2246G,80
+Intel Xeon E-2254ME,45
+Intel Xeon E-2254ML,25
+Intel Xeon E-2274G,83
+Intel Xeon E-2276G,80
+Intel Xeon E-2276M,45
+Intel Xeon E-2276ME,45
+Intel Xeon E-2276ML,25
+Intel Xeon E-2278G,80
+Intel Xeon E-2278GE,80
+Intel Xeon E-2278GEL,35
+Intel Xeon E-2286G,95
+Intel Xeon E-2286M,45
+Intel Xeon E-2288G,95
+Intel Xeon E-2314,65
+Intel Xeon E-2324G,65
+Intel Xeon E-2334,65
+Intel Xeon E-2336,65
+Intel Xeon E-2356G,80
+Intel Xeon E-2374G,80
+Intel Xeon E-2378,65
+Intel Xeon E-2378G,80
+Intel Xeon E-2386G,95
+Intel Xeon E-2388G,95
+Intel Xeon E3-1105C,25
+Intel Xeon E3-1105C v2,25
+Intel Xeon E3-1125C,40
+Intel Xeon E3-1125C v2,40
+Intel Xeon E3-1135C v2,55
+Intel Xeon E3-1205 v6,65
 Intel Xeon E3-1220,80
 Intel Xeon E3-1220 v2,69
+Intel Xeon E3-1220 v5,80
+Intel Xeon E3-1220 v6,72
 Intel Xeon E3-1220L,20
 Intel Xeon E3-1220L v2,17
 Intel Xeon E3-1225,95
 Intel Xeon E3-1225 v2,77
+Intel Xeon E3-1225 v5,80
+Intel Xeon E3-1225 v6,73
 Intel Xeon E3-1230,80
 Intel Xeon E3-1230 v2,69
+Intel Xeon E3-1230 v5,80
+Intel Xeon E3-1230 v6,72
 Intel Xeon E3-1235,95
+Intel Xeon E3-1235L v5,25
 Intel Xeon E3-1240,80
 Intel Xeon E3-1240 v2,69
+Intel Xeon E3-1240 v5,80
+Intel Xeon E3-1240 v6,72
+Intel Xeon E3-1240L v5,25
 Intel Xeon E3-1245,95
 Intel Xeon E3-1245 v2,77
+Intel Xeon E3-1245 v5,80
+Intel Xeon E3-1245 v6,73
+Intel Xeon E3-1258L v4,47
 Intel Xeon E3-1260L,45
+Intel Xeon E3-1260L v5,45
+Intel Xeon E3-1265L,45
 Intel Xeon E3-1265L v2,45
+Intel Xeon E3-1265L v4,35
+Intel Xeon E3-1268L v5,35
 Intel Xeon E3-1270,80
 Intel Xeon E3-1270 v2,69
+Intel Xeon E3-1270 v5,80
+Intel Xeon E3-1270 v6,72
+Intel Xeon E3-1270L v4,45
 Intel Xeon E3-1275,95
 Intel Xeon E3-1275 v2,77
+Intel Xeon E3-1275 v5,80
+Intel Xeon E3-1275 v6,73
+Intel Xeon E3-1278L v4,47
 Intel Xeon E3-1280,95
 Intel Xeon E3-1280 v2,69
 Intel Xeon E3-1280 v5,80
+Intel Xeon E3-1280 v6,72
+Intel Xeon E3-1283L v4,47
+Intel Xeon E3-1284L v4,47
+Intel Xeon E3-1285 v2,77
 Intel Xeon E3-1285 v4,95
 Intel Xeon E3-1285 v6,79
+Intel Xeon E3-1285L v2,65
+Intel Xeon E3-1285L v4,65
 Intel Xeon E3-1290,95
 Intel Xeon E3-1290 v2,87
+Intel Xeon E3-1501L v6,25
+Intel Xeon E3-1501M v6,45
+Intel Xeon E3-1505L v5,25
+Intel Xeon E3-1505L v6,25
+Intel Xeon E3-1505M v5,45
+Intel Xeon E3-1505M v6,45
+Intel Xeon E3-1515M v5,45
+Intel Xeon E3-1535M v5,45
+Intel Xeon E3-1535M v6,45
+Intel Xeon E3-1545M v5,45
+Intel Xeon E3-1558L v5,45
+Intel Xeon E3-1565L v5,35
+Intel Xeon E3-1575M v5,45
+Intel Xeon E3-1578L v5,45
+Intel Xeon E3-1585 v5,65
+Intel Xeon E3-1585L v5,45
+Intel Xeon E3110,65
+Intel Xeon E3113,65
+Intel Xeon E3120,65
+Intel Xeon E5-1410,80
+Intel Xeon E5-1410 v2,80
+Intel Xeon E5-1428L,60
+Intel Xeon E5-1428L v2,60
+Intel Xeon E5-1603,130
 Intel Xeon E5-1603 v3,140
+Intel Xeon E5-1603 v4,140
+Intel Xeon E5-1607,130
+Intel Xeon E5-1607 v2,130
+Intel Xeon E5-1607 v4,140
+Intel Xeon E5-1620,130
 Intel Xeon E5-1620 v2,130
+Intel Xeon E5-1620 v4,140
+Intel Xeon E5-1630 v4,140
+Intel Xeon E5-1650,130
 Intel Xeon E5-1650 v2,130
 Intel Xeon E5-1650 v4,140
+Intel Xeon E5-1660,130
 Intel Xeon E5-1660 v2,130
+Intel Xeon E5-1660 v4,140
+Intel Xeon E5-1680 v2,130
+Intel Xeon E5-1680 v4,140
+Intel Xeon E5-2403,80
 Intel Xeon E5-2403 v2,80
+Intel Xeon E5-2407,80
 Intel Xeon E5-2407 v2,80
+Intel Xeon E5-2418L,50
+Intel Xeon E5-2418L v2,50
+Intel Xeon E5-2420,95
 Intel Xeon E5-2420 v2,80
+Intel Xeon E5-2428L,60
+Intel Xeon E5-2428L v2,60
+Intel Xeon E5-2430,95
 Intel Xeon E5-2430 v2,80
+Intel Xeon E5-2430L,60
+Intel Xeon E5-2430L v2,60
+Intel Xeon E5-2440,95
 Intel Xeon E5-2440 v2,95
+Intel Xeon E5-2448L,70
+Intel Xeon E5-2448L v2,70
+Intel Xeon E5-2449L,50
+Intel Xeon E5-2450,95
 Intel Xeon E5-2450 v2,95
+Intel Xeon E5-2450L,70
+Intel Xeon E5-2450L v2,60
+Intel Xeon E5-2470,95
 Intel Xeon E5-2470 v2,95
+Intel Xeon E5-2603,80
 Intel Xeon E5-2603 v2,80
+Intel Xeon E5-2603 v4,85
+Intel Xeon E5-2608L v4,50
+Intel Xeon E5-2609,80
 Intel Xeon E5-2609 v2,80
+Intel Xeon E5-2609 v4,85
+Intel Xeon E5-2618L,40
+Intel Xeon E5-2618L v2,50
+Intel Xeon E5-2618L v4,75
+Intel Xeon E5-2620,95
 Intel Xeon E5-2620 v2,80
+Intel Xeon E5-2620 v4,85
+Intel Xeon E5-2623 v4,85
+Intel Xeon E5-2628L,60
+Intel Xeon E5-2628L v2,70
+Intel Xeon E5-2628L v4,75
+Intel Xeon E5-2630,95
 Intel Xeon E5-2630 v2,80
+Intel Xeon E5-2630 v4,85
+Intel Xeon E5-2630L,60
 Intel Xeon E5-2630L v2,60
+Intel Xeon E5-2630L v4,55
+Intel Xeon E5-2637,80
 Intel Xeon E5-2637 v2,130
+Intel Xeon E5-2637 v4,135
+Intel Xeon E5-2640,95
 Intel Xeon E5-2640 v2,95
+Intel Xeon E5-2640 v4,90
+Intel Xeon E5-2643,130
 Intel Xeon E5-2643 v2,130
+Intel Xeon E5-2643 v4,135
+Intel Xeon E5-2648L,70
+Intel Xeon E5-2648L v2,70
+Intel Xeon E5-2648L v4,75
+Intel Xeon E5-2650,95
 Intel Xeon E5-2650 v2,95
+Intel Xeon E5-2650 v4,105
+Intel Xeon E5-2650L,70
 Intel Xeon E5-2650L v2,70
+Intel Xeon E5-2650L v4,65
+Intel Xeon E5-2651 v2,105
+Intel Xeon E5-2658,95
+Intel Xeon E5-2658 v2,95
+Intel Xeon E5-2658 v4,105
+Intel Xeon E5-2660,95
 Intel Xeon E5-2660 v2,95
-Intel Xeon E5-2667 v2,130
-Intel Xeon E5-2670 v2,115
-Intel Xeon E5-2673 v3,110
 Intel Xeon E5-2660 v4,105
+Intel Xeon E5-2665,115
+Intel Xeon E5-2666 v4,145
+Intel Xeon E5-2667,130
+Intel Xeon E5-2667 v2,130
+Intel Xeon E5-2667 v4,135
+Intel Xeon E5-2670,115
+Intel Xeon E5-2670 v2,115
+Intel Xeon E5-2673 v2,110
+Intel Xeon E5-2673 v3,110
+Intel Xeon E5-2673 v4,135
+Intel Xeon E5-2676 v4,145
+Intel Xeon E5-2679 v4,200
+Intel Xeon E5-2680,130
 Intel Xeon E5-2680 v2,115
 Intel Xeon E5-2680 v3,120
 Intel Xeon E5-2680 v4,120
+Intel Xeon E5-2682 v4,120
+Intel Xeon E5-2683 v4,120
+Intel Xeon E5-2686 v4,145
+Intel Xeon E5-2687W,150
 Intel Xeon E5-2687W v2,130
+Intel Xeon E5-2687W v4,160
+Intel Xeon E5-2689,115
+Intel Xeon E5-2689 v4,165
+Intel Xeon E5-2689A v4,145
+Intel Xeon E5-2690,135
 Intel Xeon E5-2690 v2,130
+Intel Xeon E5-2690 v4,135
 Intel Xeon E5-2692 v2,100
 Intel Xeon E5-2695 v2,115
+Intel Xeon E5-2695 v4,120
+Intel Xeon E5-2696 v2,120
+Intel Xeon E5-2696 v4,150
 Intel Xeon E5-2697 v2,130
+Intel Xeon E5-2697 v4,145
+Intel Xeon E5-2697A v4,145
+Intel Xeon E5-2698 v4,135
+Intel Xeon E5-2699 v4,145
+Intel Xeon E5-2699A v4,145
+Intel Xeon E5-2699C v4,145
+Intel Xeon E5-2699P v4,300
+Intel Xeon E5-2699R v4,145
+Intel Xeon E5-4603,95
+Intel Xeon E5-4603 v2,95
 Intel Xeon E5-4607,95
+Intel Xeon E5-4607 v2,95
 Intel Xeon E5-4610,130
-Intel Xeon 5320,185
+Intel Xeon E5-4610 v2,95
+Intel Xeon E5-4610 v4,105
+Intel Xeon E5-4617,130
+Intel Xeon E5-4620,95
+Intel Xeon E5-4620 v2,95
+Intel Xeon E5-4620 v4,105
+Intel Xeon E5-4624L v2,70
+Intel Xeon E5-4627 v2,130
+Intel Xeon E5-4627 v4,135
+Intel Xeon E5-4628L v4,75
+Intel Xeon E5-4640,95
+Intel Xeon E5-4640 v2,95
+Intel Xeon E5-4640 v4,105
+Intel Xeon E5-4650,130
+Intel Xeon E5-4650 v2,95
+Intel Xeon E5-4650 v4,105
+Intel Xeon E5-4650L,115
+Intel Xeon E5-4655 v4,135
+Intel Xeon E5-4657L v2,115
+Intel Xeon E5-4660 v4,120
+Intel Xeon E5-4667 v4,135
+Intel Xeon E5-4669 v4,135
+Intel Xeon E5205,65
+Intel Xeon E5220,65
+Intel Xeon E5240,65
+Intel Xeon E5310,80
+Intel Xeon E5320,80
+Intel Xeon E5330,80
+Intel Xeon E5335,80
+Intel Xeon E5340,80
+Intel Xeon E5345,80
+Intel Xeon E5350,120
+Intel Xeon E5405,80
+Intel Xeon E5410,80
+Intel Xeon E5420,80
+Intel Xeon E5430,80
+Intel Xeon E5440,80
+Intel Xeon E5450,80
+Intel Xeon E5462,80
+Intel Xeon E5472,80
 Intel Xeon E5502,80
 Intel Xeon E5503,80
 Intel Xeon E5504,80
@@ -2046,24 +3324,268 @@ Intel Xeon E5620,80
 Intel Xeon E5630,80
 Intel Xeon E5640,80
 Intel Xeon E5645,80
+Intel Xeon E5649,80
+Intel Xeon E6510,105
+Intel Xeon E6540,105
+Intel Xeon E7-2803,105
+Intel Xeon E7-2820,105
+Intel Xeon E7-2830,105
+Intel Xeon E7-2850,130
+Intel Xeon E7-2850 v2,105
+Intel Xeon E7-2860,130
+Intel Xeon E7-2870,130
+Intel Xeon E7-2870 v2,130
+Intel Xeon E7-2880 v2,130
+Intel Xeon E7-2890 v2,155
+Intel Xeon E7-4807,95
+Intel Xeon E7-4809 v2,105
 Intel Xeon E7-4809 v3,115
+Intel Xeon E7-4809 v4,115
+Intel Xeon E7-4820,105
+Intel Xeon E7-4820 v2,105
 Intel Xeon E7-4820 v3,115
+Intel Xeon E7-4820 v4,115
+Intel Xeon E7-4830,105
+Intel Xeon E7-4830 v2,105
 Intel Xeon E7-4830 v3,115
+Intel Xeon E7-4830 v4,115
+Intel Xeon E7-4850,130
+Intel Xeon E7-4850 v2,105
 Intel Xeon E7-4850 v3,115
+Intel Xeon E7-4850 v4,115
+Intel Xeon E7-4860,130
+Intel Xeon E7-4860 v2,130
+Intel Xeon E7-4870,130
+Intel Xeon E7-4870 v2,130
+Intel Xeon E7-4880 v2,130
+Intel Xeon E7-4890 v2,155
+Intel Xeon E7-8830,105
+Intel Xeon E7-8837,130
 Intel Xeon E7-8850,130
+Intel Xeon E7-8850 v2,105
+Intel Xeon E7-8855 v4,140
+Intel Xeon E7-8857 v2,130
 Intel Xeon E7-8860,130
 Intel Xeon E7-8860 v3,140
+Intel Xeon E7-8860 v4,140
 Intel Xeon E7-8867 v3,165
+Intel Xeon E7-8867 v4,165
+Intel Xeon E7-8867L,105
 Intel Xeon E7-8870,130
+Intel Xeon E7-8870 v2,130
 Intel Xeon E7-8870 v3,140
+Intel Xeon E7-8870 v4,140
+Intel Xeon E7-8880 v2,130
 Intel Xeon E7-8880 v3,150
+Intel Xeon E7-8880 v4,150
+Intel Xeon E7-8880L v2,105
 Intel Xeon E7-8880L v3,115
+Intel Xeon E7-8890 v2,155
 Intel Xeon E7-8890 v3,165
+Intel Xeon E7-8890 v4,165
+Intel Xeon E7-8891 v2,155
 Intel Xeon E7-8891 v3,165
+Intel Xeon E7-8891 v4,165
+Intel Xeon E7-8893 v2,155
 Intel Xeon E7-8893 v3,140
-Intel Xeon Gold 6154,200
+Intel Xeon E7-8893 v4,140
+Intel Xeon E7-8894 v4,165
+Intel Xeon E7-8895 v2,155
+Intel Xeon E7210,80
+Intel Xeon E7220,80
+Intel Xeon E7310,80
+Intel Xeon E7320,80
+Intel Xeon E7330,80
+Intel Xeon E7340,80
+Intel Xeon E7420,90
+Intel Xeon E7430,90
+Intel Xeon E7440,90
+Intel Xeon E7450,90
+Intel Xeon E7458,90
+Intel Xeon E7520,105
+Intel Xeon E7530,105
+Intel Xeon E7540,105
+Intel Xeon EC3539,65
+Intel Xeon EC5509,85
+Intel Xeon EC5539,65
+Intel Xeon EC5549,85
+Intel Xeon Gold 5115,85
+Intel Xeon Gold 5117,105
+Intel Xeon Gold 5117F,113
+Intel Xeon Gold 5118,105
+Intel Xeon Gold 5119T,85
+Intel Xeon Gold 5120,105
+Intel Xeon Gold 5120T,105
+Intel Xeon Gold 5122,105
+Intel Xeon Gold 5213W,100
+Intel Xeon Gold 5215,85
+Intel Xeon Gold 5215L,85
+Intel Xeon Gold 5215M,85
+Intel Xeon Gold 5215R,100
+Intel Xeon Gold 5216W,160
+Intel Xeon Gold 5217,115
+Intel Xeon Gold 5218,125
+Intel Xeon Gold 5218B,125
+Intel Xeon Gold 5218N,110
+Intel Xeon Gold 5218R,125
+Intel Xeon Gold 5218T,105
+Intel Xeon Gold 5219Y,125
+Intel Xeon Gold 5220,125
+Intel Xeon Gold 5220R,150
+Intel Xeon Gold 5220S,125
+Intel Xeon Gold 5220T,105
+Intel Xeon Gold 5222,105
+Intel Xeon Gold 5315Y,140
+Intel Xeon Gold 5317,150
+Intel Xeon Gold 5318H,150
+Intel Xeon Gold 5318N,150
+Intel Xeon Gold 5318S,165
+Intel Xeon Gold 5318Y,165
+Intel Xeon Gold 5320,185
+Intel Xeon Gold 5320H,150
+Intel Xeon Gold 5320T,150
+Intel Xeon Gold 6122,120
+Intel Xeon Gold 6126,125
+Intel Xeon Gold 6126F,135
+Intel Xeon Gold 6126T,125
+Intel Xeon Gold 6127M,145
+Intel Xeon Gold 6128,115
+Intel Xeon Gold 6130,125
+Intel Xeon Gold 6130F,135
+Intel Xeon Gold 6130H,125
+Intel Xeon Gold 6130T,125
+Intel Xeon Gold 6131,205
+Intel Xeon Gold 6132,140
+Intel Xeon Gold 6133,150
+Intel Xeon Gold 6134,130
+Intel Xeon Gold 6134M,130
+Intel Xeon Gold 6135,155
+Intel Xeon Gold 6135M,155
+Intel Xeon Gold 6136,150
+Intel Xeon Gold 6137,205
+Intel Xeon Gold 6137M,205
+Intel Xeon Gold 6138,125
+Intel Xeon Gold 6138F,135
+Intel Xeon Gold 6138P,195
+Intel Xeon Gold 6138T,125
+Intel Xeon Gold 6139,135
+Intel Xeon Gold 6139M,135
+Intel Xeon Gold 6140,140
+Intel Xeon Gold 6140M,140
+Intel Xeon Gold 6142,150
+Intel Xeon Gold 6142F,160
+Intel Xeon Gold 6142M,150
+Intel Xeon Gold 6143,165
 Intel Xeon Gold 6144,150
+Intel Xeon Gold 6145,145
+Intel Xeon Gold 6146,165
+Intel Xeon Gold 6147M,150
+Intel Xeon Gold 6148,150
+Intel Xeon Gold 6148F,150
+Intel Xeon Gold 6149,205
+Intel Xeon Gold 6150,165
+Intel Xeon Gold 6151,205
+Intel Xeon Gold 6152,140
+Intel Xeon Gold 6154,200
+Intel Xeon Gold 6155,200
+Intel Xeon Gold 6159,145
+Intel Xeon Gold 6161,165
+Intel Xeon Gold 6162,150
+Intel Xeon Gold 6164,150
+Intel Xeon Gold 6208U,150
+Intel Xeon Gold 6209U,125
+Intel Xeon Gold 6210U,150
+Intel Xeon Gold 6212U,165
+Intel Xeon Gold 6222,115
+Intel Xeon Gold 6222V,115
+Intel Xeon Gold 6226,125
+Intel Xeon Gold 6226R,150
+Intel Xeon Gold 6230,125
 Intel Xeon Gold 6230N,125
+Intel Xeon Gold 6230R,150
+Intel Xeon Gold 6230T,125
+Intel Xeon Gold 6231,185
+Intel Xeon Gold 6231C,185
+Intel Xeon Gold 6233,165
+Intel Xeon Gold 6234,130
+Intel Xeon Gold 6238,140
+Intel Xeon Gold 6238L,140
+Intel Xeon Gold 6238M,140
+Intel Xeon Gold 6238R,165
+Intel Xeon Gold 6238T,125
+Intel Xeon Gold 6240,150
+Intel Xeon Gold 6240C,150
+Intel Xeon Gold 6240L,150
+Intel Xeon Gold 6240M,150
+Intel Xeon Gold 6240R,165
+Intel Xeon Gold 6240Y,150
+Intel Xeon Gold 6241W,205
+Intel Xeon Gold 6242,150
+Intel Xeon Gold 6242R,205
+Intel Xeon Gold 6244,150
+Intel Xeon Gold 6245W,180
+Intel Xeon Gold 6246,165
+Intel Xeon Gold 6246R,205
+Intel Xeon Gold 6248,150
+Intel Xeon Gold 6248R,205
+Intel Xeon Gold 6250,185
+Intel Xeon Gold 6250L,185
+Intel Xeon Gold 6252,150
+Intel Xeon Gold 6252N,150
+Intel Xeon Gold 6253CL,205
+Intel Xeon Gold 6253W,200
+Intel Xeon Gold 6254,200
+Intel Xeon Gold 6256,205
+Intel Xeon Gold 6258R,205
+Intel Xeon Gold 6261,205
+Intel Xeon Gold 6262,135
+Intel Xeon Gold 6262V,135
+Intel Xeon Gold 6263CY,205
+Intel Xeon Gold 6266C,205
+Intel Xeon Gold 6267,165
+Intel Xeon Gold 6267C,165
+Intel Xeon Gold 6268CL,205
+Intel Xeon Gold 6269Y,240
+Intel Xeon Gold 6271C,165
+Intel Xeon Gold 6273C,165
+Intel Xeon Gold 6278C,185
+Intel Xeon Gold 6290,240
+Intel Xeon Gold 6312U,185
+Intel Xeon Gold 6314U,205
+Intel Xeon Gold 6326,185
+Intel Xeon Gold 6328H,165
+Intel Xeon Gold 6328HL,165
+Intel Xeon Gold 6330,205
+Intel Xeon Gold 6330H,150
+Intel Xeon Gold 6330N,165
+Intel Xeon Gold 6334,165
+Intel Xeon Gold 6336Y,185
+Intel Xeon Gold 6338,205
+Intel Xeon Gold 6338N,185
+Intel Xeon Gold 6338T,165
+Intel Xeon Gold 6342,230
+Intel Xeon Gold 6346,205
+Intel Xeon Gold 6348,235
+Intel Xeon Gold 6348H,165
+Intel Xeon Gold 6354,205
+Intel Xeon L3014,30
+Intel Xeon L3110,45
+Intel Xeon L3360,65
+Intel Xeon L3403,30
+Intel Xeon L3406,30
+Intel Xeon L3426,45
+Intel Xeon L5215,20
+Intel Xeon L5238,35
+Intel Xeon L5240,40
+Intel Xeon L5248,55
+Intel Xeon L5310,50
+Intel Xeon L5318,40
+Intel Xeon L5320,50
+Intel Xeon L5335,50
+Intel Xeon L5408,40
+Intel Xeon L5410,50
+Intel Xeon L5420,50
+Intel Xeon L5430,50
 Intel Xeon L5506,60
 Intel Xeon L5508,38
 Intel Xeon L5518,60
@@ -2073,24 +3595,50 @@ Intel Xeon L5609,40
 Intel Xeon L5618,40
 Intel Xeon L5630,40
 Intel Xeon L5638,60
+Intel Xeon L5639,60
 Intel Xeon L5640,60
+Intel Xeon L5645,60
+Intel Xeon L7345,50
+Intel Xeon L7445,50
+Intel Xeon L7455,65
+Intel Xeon L7545,95
+Intel Xeon L7555,95
+Intel Xeon LC3518,23
+Intel Xeon LC3528,35
+Intel Xeon LC5518,48
+Intel Xeon LC5528,60
+Intel Xeon LV 1.6,30
+Intel Xeon LV 2.0,35
+Intel Xeon LV 2.4,40
+Intel Xeon LV 2.8,55
+Intel Xeon LV 3.0,55
+Intel Xeon LV 5113,40
+Intel Xeon LV 5128,40
+Intel Xeon LV 5133,40
+Intel Xeon LV 5138,35
+Intel Xeon LV 5148,40
+Intel Xeon MP 1.4,64
+Intel Xeon MP 1.5,48
+Intel Xeon MP 1.6,72
+Intel Xeon MP 1.9,55
+Intel Xeon MP 2.0,57
+Intel Xeon MP 2.2,65
+Intel Xeon MP 2.5,66
+Intel Xeon MP 2.7,80
+Intel Xeon MP 2.8,72
 Intel Xeon MP 2.83,135
-Intel Xeon MP 2.83,135
+Intel Xeon MP 3.0,129
 Intel Xeon MP 3.00,135
-Intel Xeon MP 3.00,135
 Intel Xeon MP 3.16,135
-Intel Xeon MP 3.16,135
-Intel Xeon MP 3.16,135
-Intel Xeon MP 3.33,135
-Intel Xeon MP 3.33,135
 Intel Xeon MP 3.33,135
 Intel Xeon MP 3.50,135
 Intel Xeon MP 3.66,135
 Intel Xeon MP 7020 Dual-Core,135
 Intel Xeon MP 7030 Dual-Core,135
-Intel Xeon MP 7030 Dual-Core,135
 Intel Xeon MP 7040 Dual-Core,135
 Intel Xeon MP 7041 Dual-Core,135
+Intel Xeon MV 3.2,90
+Intel Xeon MV 5063,95
 Intel Xeon Phi 3110X,300
 Intel Xeon Phi 3120A,300
 Intel Xeon Phi 3120P,300
@@ -2116,27 +3664,184 @@ Intel Xeon Phi 7290F,260
 Intel Xeon Phi 7295,320
 Intel Xeon Phi SE10P,300
 Intel Xeon Phi SE10X,300
+Intel Xeon Platinum 8124M,240
+Intel Xeon Platinum 8151,240
+Intel Xeon Platinum 8153,125
+Intel Xeon Platinum 8156,105
+Intel Xeon Platinum 8157M,145
+Intel Xeon Platinum 8158,150
+Intel Xeon Platinum 8160,150
+Intel Xeon Platinum 8160F,160
+Intel Xeon Platinum 8160H,150
+Intel Xeon Platinum 8160M,150
+Intel Xeon Platinum 8160T,150
+Intel Xeon Platinum 8163,165
+Intel Xeon Platinum 8164,150
+Intel Xeon Platinum 8165,165
+Intel Xeon Platinum 8167M,165
+Intel Xeon Platinum 8168,205
+Intel Xeon Platinum 8170,165
+Intel Xeon Platinum 8170M,165
 Intel Xeon Platinum 8171M,165
+Intel Xeon Platinum 8172M,205
+Intel Xeon Platinum 8173M,165
+Intel Xeon Platinum 8174,240
+Intel Xeon Platinum 8175M,240
+Intel Xeon Platinum 8176,165
+Intel Xeon Platinum 8176F,173
+Intel Xeon Platinum 8176M,165
+Intel Xeon Platinum 8179M,240
 Intel Xeon Platinum 8180,205
 Intel Xeon Platinum 8180M,205
+Intel Xeon Platinum 8222L,200
+Intel Xeon Platinum 8249C,150
+Intel Xeon Platinum 8251,240
 Intel Xeon Platinum 8253,125
+Intel Xeon Platinum 8255C,165
 Intel Xeon Platinum 8256,105
 Intel Xeon Platinum 8259CL,210
+Intel Xeon Platinum 8259L,210
 Intel Xeon Platinum 8260,165
+Intel Xeon Platinum 8260L,165
 Intel Xeon Platinum 8260M,165
+Intel Xeon Platinum 8260Y,165
+Intel Xeon Platinum 8263C,165
+Intel Xeon Platinum 8267W,205
 Intel Xeon Platinum 8268,205
+Intel Xeon Platinum 8269CY,205
 Intel Xeon Platinum 8270,205
+Intel Xeon Platinum 8272CL,195
+Intel Xeon Platinum 8272L,195
+Intel Xeon Platinum 8273CL,165
+Intel Xeon Platinum 8274,240
+Intel Xeon Platinum 8275CL,240
 Intel Xeon Platinum 8276,165
+Intel Xeon Platinum 8276L,165
+Intel Xeon Platinum 8276M,165
+Intel Xeon Platinum 8279W,205
 Intel Xeon Platinum 8280,205
+Intel Xeon Platinum 8280L,205
 Intel Xeon Platinum 8280M,205
+Intel Xeon Platinum 8284,240
+Intel Xeon Platinum 8347C,210
+Intel Xeon Platinum 8351N,225
+Intel Xeon Platinum 8352M,185
+Intel Xeon Platinum 8352S,205
+Intel Xeon Platinum 8352V,195
+Intel Xeon Platinum 8352Y,205
+Intel Xeon Platinum 8353H,150
+Intel Xeon Platinum 8354H,205
+Intel Xeon Platinum 8356H,190
+Intel Xeon Platinum 8357C,240
+Intel Xeon Platinum 8358,250
+Intel Xeon Platinum 8358P,240
+Intel Xeon Platinum 8360H,225
+Intel Xeon Platinum 8360HL,225
+Intel Xeon Platinum 8360Y,250
+Intel Xeon Platinum 8362,265
+Intel Xeon Platinum 8368,270
+Intel Xeon Platinum 8368Q,270
+Intel Xeon Platinum 8372C,300
+Intel Xeon Platinum 8373C,300
+Intel Xeon Platinum 8375C,300
+Intel Xeon Platinum 8376H,205
+Intel Xeon Platinum 8376HL,205
+Intel Xeon Platinum 8380,270
+Intel Xeon Platinum 8380H,250
+Intel Xeon Platinum 8380HL,250
 Intel Xeon Platinum 9221,250
 Intel Xeon Platinum 9222,250
 Intel Xeon Platinum 9242,350
 Intel Xeon Platinum 9282,400
+Intel Xeon Platinum P-8124,240
+Intel Xeon Platinum P-8136,165
+Intel Xeon Silver 4106H,85
+Intel Xeon Silver 4108,85
+Intel Xeon Silver 4109T,70
+Intel Xeon Silver 4110,85
+Intel Xeon Silver 4112,85
+Intel Xeon Silver 4114,85
+Intel Xeon Silver 4114T,85
 Intel Xeon Silver 4116,85
+Intel Xeon Silver 4116T,85
+Intel Xeon Silver 4123,105
+Intel Xeon Silver 4208, 85
+Intel Xeon Silver 4209T,70
+Intel Xeon Silver 4210,85
+Intel Xeon Silver 4210R,100
+Intel Xeon Silver 4210T,95
+Intel Xeon Silver 4211W,100
+Intel Xeon Silver 4213W,115
+Intel Xeon Silver 4214,85
+Intel Xeon Silver 4214R,100
+Intel Xeon Silver 4214Y,85
+Intel Xeon Silver 4215,85
+Intel Xeon Silver 4215R,130
+Intel Xeon Silver 4216,100
+Intel Xeon Silver 4216R,125
+Intel Xeon Silver 4309Y,105
+Intel Xeon Silver 4310,120
+Intel Xeon Silver 4310T,105
+Intel Xeon Silver 4314,135
+Intel Xeon Silver 4316,150
+Intel Xeon W-10855M,45
+Intel Xeon W-10885M,45
+Intel Xeon W-1250,80
+Intel Xeon W-1250E,80
+Intel Xeon W-1250P,125
+Intel Xeon W-1250TE,35
+Intel Xeon W-1270,80
+Intel Xeon W-1270E,80
+Intel Xeon W-1270P,125
+Intel Xeon W-1270TE,35
+Intel Xeon W-1290,80
+Intel Xeon W-1290E,95
+Intel Xeon W-1290P,125
+Intel Xeon W-1290T,35
+Intel Xeon W-1290TE,35
+Intel Xeon W-1350,80
+Intel Xeon W-1350P,125
+Intel Xeon W-1370,80
+Intel Xeon W-1370P,125
+Intel Xeon W-1390,80
+Intel Xeon W-1390P,125
+Intel Xeon W-1390T,35
+Intel Xeon W-2102,120
+Intel Xeon W-2104,120
+Intel Xeon W-2123,120
+Intel Xeon W-2125,120
+Intel Xeon W-2133,140
+Intel Xeon W-2135,140
+Intel Xeon W-2140B,120
+Intel Xeon W-2145,140
+Intel Xeon W-2150B,120
+Intel Xeon W-2155,140
+Intel Xeon W-2175,140
+Intel Xeon W-2191B,140
 Intel Xeon W-2195,140
+Intel Xeon W-2223,120
+Intel Xeon W-2225,105
+Intel Xeon W-2235,130
+Intel Xeon W-2245,155
+Intel Xeon W-2255,165
+Intel Xeon W-2265,165
 Intel Xeon W-2275,165
+Intel Xeon W-2295,165
 Intel Xeon W-3175X,255
+Intel Xeon W-3223,160
+Intel Xeon W-3225,160
+Intel Xeon W-3235,180
+Intel Xeon W-3245,205
+Intel Xeon W-3245M,205
+Intel Xeon W-3265,205
+Intel Xeon W-3265M,205
+Intel Xeon W-3275,205
+Intel Xeon W-3275M,205
+Intel Xeon W-3323,220
+Intel Xeon W-3335,250
+Intel Xeon W-3345,250
+Intel Xeon W-3365,270
+Intel Xeon W-3375,270
 Intel Xeon W3503,130
 Intel Xeon W3505,130
 Intel Xeon W3520,130
@@ -2151,6 +3856,35 @@ Intel Xeon W3680,130
 Intel Xeon W3690,130
 Intel Xeon W5580,130
 Intel Xeon W5590,130
+Intel Xeon X3210,100
+Intel Xeon X3220,100
+Intel Xeon X3230,100
+Intel Xeon X3320,95
+Intel Xeon X3323,80
+Intel Xeon X3330,95
+Intel Xeon X3350,95
+Intel Xeon X3353,80
+Intel Xeon X3360,95
+Intel Xeon X3363,80
+Intel Xeon X3370,95
+Intel Xeon X3380,95
+Intel Xeon X3430,95
+Intel Xeon X3440,95
+Intel Xeon X3450,95
+Intel Xeon X3460,95
+Intel Xeon X3470,95
+Intel Xeon X3480,95
+Intel Xeon X5260,80
+Intel Xeon X5270,80
+Intel Xeon X5272,80
+Intel Xeon X5355,120
+Intel Xeon X5365,120
+Intel Xeon X5450,120
+Intel Xeon X5460,120
+Intel Xeon X5470,120
+Intel Xeon X5472,120
+Intel Xeon X5482,150
+Intel Xeon X5492,150
 Intel Xeon X5550,95
 Intel Xeon X5560,95
 Intel Xeon X5570,95
@@ -2160,7 +3894,30 @@ Intel Xeon X5660,95
 Intel Xeon X5667,95
 Intel Xeon X5670,95
 Intel Xeon X5672,95
+Intel Xeon X5675,95
 Intel Xeon X5677,130
+Intel Xeon X5679,115
 Intel Xeon X5680,130
 Intel Xeon X5687,130
-Intel Xeon Silver 4208, 85
+Intel Xeon X5690,130
+Intel Xeon X5698,130
+Intel Xeon X6550,130
+Intel Xeon X7350,130
+Intel Xeon X7460,130
+Intel Xeon X7542,130
+Intel Xeon X7550,130
+Intel Xeon X7560,130
+N640,35
+N660,35
+N870,35
+N960,35
+N970,35
+P650,35
+P860,35
+Sempron 2650 APU with Radeon R3 Series,25
+Sempron 3850 APU with Radeon R3 Series,25
+TL-52,31
+TL-60,31
+TL-64,35
+X1150,17
+X940,45


### PR DESCRIPTION
As described in issue #532, I merged the TDP values with the data in the eco2ai project. For contrasting values, a search was made to find the right one or the value from code carbon was kept; except when the difference was inferior to 1 (due to int-float difference), motivating the adoption of eco2ai's float value. The list of contrasting values can be found in the issue.